### PR TITLE
Update add command, nric and phone

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -41,8 +41,8 @@ public class AddCommand extends Command {
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
-            + PREFIX_TAG + "friends "
-            + PREFIX_TAG + "owesMoney";
+            + PREFIX_TAG + "Patient "
+            + PREFIX_TAG + "OwesMoney";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -28,7 +28,7 @@ public class Name {
     public Name(String name) {
         requireNonNull(name);
         checkArgument(isValidName(name), MESSAGE_CONSTRAINTS);
-        fullName = name;
+        fullName = name.trim().replaceAll(" +", " ");
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Nric.java
+++ b/src/main/java/seedu/address/model/person/Nric.java
@@ -25,8 +25,9 @@ public class Nric {
      * @param nric A valid NRIC.
      */
     public Nric(String nric) {
-        requireNonNull(nric);
-        checkArgument(isValidNric(nric), MESSAGE_CONSTRAINTS);
+        String newNric = nric.toUpperCase();
+        requireNonNull(newNric);
+        checkArgument(isValidNric(newNric), MESSAGE_CONSTRAINTS);
         fullNric = nric;
     }
 
@@ -54,7 +55,7 @@ public class Nric {
         }
 
         Nric otherNric = (Nric) other;
-        return fullNric.equals(otherNric.fullNric);
+        return fullNric.equalsIgnoreCase(otherNric.fullNric);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -90,8 +90,7 @@ public class Person {
             return true;
         }
 
-        return otherPerson != null
-                && otherPerson.getNric().equals(getNric());
+        return otherPerson != null && otherPerson.getNric().equals(getNric());
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -82,7 +82,7 @@ public class Person {
     }
 
     /**
-     * Returns true if both persons have the same name.
+     * Returns true if both persons have the same NRIC since they are unique.
      * This defines a weaker notion of equality between two persons.
      */
     public boolean isSamePerson(Person otherPerson) {
@@ -91,7 +91,7 @@ public class Person {
         }
 
         return otherPerson != null
-                && otherPerson.getName().equals(getName());
+                && otherPerson.getNric().equals(getNric());
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -11,8 +11,8 @@ public class Phone {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should only contain numbers, and it should be at least 3 digits long";
-    public static final String VALIDATION_REGEX = "\\d{3,}";
+            "Phone numbers should only contain numbers, and it should be 8 digits long";
+    public static final String VALIDATION_REGEX = "\\d{8}";
     public final String value;
 
     /**

--- a/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidAndValidPersonAddressBook.json
@@ -4,7 +4,7 @@
     "age" : "32",
     "gender": "M",
     "nric": "S1234567Z",
-    "phone": "9482424",
+    "phone": "94823424",
     "email": "hans@example.com",
     "address": "4th street"
   }, {

--- a/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonAddressBookStorageTest/invalidPersonAddressBook.json
@@ -4,7 +4,7 @@
     "age" : "32",
     "gender": "M",
     "nric": "S1234567Z",
-    "phone": "9482424",
+    "phone": "94824234",
     "email": "hans@example.com",
     "address": "4th street"
   } ]

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -5,7 +5,7 @@
     "age" : "30",
     "gender" : "F",
     "nric" : "S1234567Z",
-    "phone" : "94351253",
+    "phone" : "12345678",
     "email" : "alice@example.com",
     "address" : "123, Jurong West Ave 6, #08-111",
     "tags" : [ "friends" ]
@@ -14,7 +14,7 @@
     "age" : "53",
     "gender" : "M",
     "nric" : "S1111111Z",
-    "phone" : "98765432",
+    "phone" : "83648172",
     "email" : "johnd@example.com",
     "address" : "311, Clementi Ave 2, #02-25",
     "tags" : [ "owesMoney", "friends" ]
@@ -23,7 +23,7 @@
     "age" : "38",
     "gender" : "M",
     "nric" : "S2222222Z",
-    "phone" : "95352563",
+    "phone" : "74526283",
     "email" : "heinz@example.com",
     "address" : "wall street",
     "tags" : [ ]
@@ -32,7 +32,7 @@
     "age" : "12",
     "gender" : "M",
     "nric" : "S3333333Z",
-    "phone" : "87652533",
+    "phone" : "84517263",
     "email" : "cornelia@example.com",
     "address" : "10th street",
     "tags" : [ "friends" ]
@@ -41,7 +41,7 @@
     "age" : "43",
     "gender" : "F",
     "nric" : "F4444444Z",
-    "phone" : "9482224",
+    "phone" : "84635473",
     "email" : "werner@example.com",
     "address" : "michegan ave",
     "tags" : [ ]
@@ -50,7 +50,7 @@
     "age" : "88",
     "gender" : "F",
     "nric" : "G8888888X",
-    "phone" : "9482427",
+    "phone" : "84657833",
     "email" : "lydia@example.com",
     "address" : "little tokyo",
     "tags" : [ ]
@@ -59,7 +59,7 @@
     "age" : "23",
     "gender" : "M",
     "nric" : "F7777777D",
-    "phone" : "9482442",
+    "phone" : "39478273",
     "email" : "anna@example.com",
     "address" : "4th street",
     "tags" : [ ]

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -54,6 +54,7 @@ public class AddCommandIntegrationTest {
                 new JsonUserPrefsStorage(temporaryFolder.resolve("expectedUserPrefs.json"));
         StorageManager expectedStorage = new StorageManager(addressBookStorage, userPrefsStorage);
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), expectedStorage);
+
         expectedModel.addPerson(validPerson);
 
         assertCommandSuccess(new AddCommand(validPerson), model,

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -35,9 +35,9 @@ public class CommandTestUtil {
     public static final String VALID_AGE_BOB = "50";
     public static final String VALID_GENDER_AMY = "F";
     public static final String VALID_GENDER_BOB = "M";
-    public static final String VALID_NRIC_AMY = "S1234567Z";
-    public static final String VALID_NRIC_BOB = "T9999999Z";
-    public static final String VALID_PHONE_AMY = "11111111";
+    public static final String VALID_NRIC_AMY = "S8374626E";
+    public static final String VALID_NRIC_BOB = "T8475728Z";
+    public static final String VALID_PHONE_AMY = "12345678";
     public static final String VALID_PHONE_BOB = "22222222";
     public static final String VALID_EMAIL_AMY = "amy@example.com";
     public static final String VALID_EMAIL_BOB = "bob@example.com";

--- a/src/test/java/seedu/address/logic/commands/UpdateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UpdateCommandTest.java
@@ -38,7 +38,8 @@ public class UpdateCommandTest {
     public void setUp() {
         JsonAddressBookStorage addressBookStorage =
                 new JsonAddressBookStorage(temporaryFolder.resolve("addressBook.json"));
-        JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.resolve("userPrefs.json"));
+        JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(
+                                                                temporaryFolder.resolve("userPrefs.json"));
         StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
 
         model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), storage);
@@ -46,7 +47,7 @@ public class UpdateCommandTest {
 
     @Test
     public void execute_allFieldsSpecified_success() {
-        Person editedPerson = new PersonBuilder().build();
+        Person editedPerson = new PersonBuilder().withNric("S1234567Z").build();
         UpdateCommand.UpdatePersonDescriptor descriptor = new UpdatePersonDescriptorBuilder(editedPerson).build();
         UpdateCommand updateCommand = new UpdateCommand(editedPerson.getNric(), descriptor);
 

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -28,7 +28,7 @@ public class ParserUtilTest {
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_NAME = "Rachel Walker";
-    private static final String VALID_PHONE = "123456";
+    private static final String VALID_PHONE = "12345678";
     private static final String VALID_ADDRESS = "123 Main Street #0505";
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_TAG_1 = "friend";

--- a/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
@@ -70,7 +70,7 @@ public class NameContainsKeywordsPredicateTest {
 
         // Keywords match phone, email and address, but does not match name
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com", "Main", "Street"));
-        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345")
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345678")
                 .withEmail("alice@email.com").withAddress("Main Street").build()));
     }
 

--- a/src/test/java/seedu/address/model/person/NricContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NricContainsKeywordsPredicateTest.java
@@ -67,7 +67,7 @@ public class NricContainsKeywordsPredicateTest {
 
         // Keywords match phone, email and address, but does not match Nric
         predicate = new NricContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com", "Main", "Street"));
-        assertFalse(predicate.test(new PersonBuilder().withNric("S1234567Z").withPhone("12345")
+        assertFalse(predicate.test(new PersonBuilder().withNric("S1234567Z").withPhone("12345678")
                 .withEmail("alice@email.com").withAddress("Main Street").build()));
     }
 

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -35,25 +35,21 @@ public class PersonTest {
         // null -> returns false
         assertFalse(ALICE.isSamePerson(null));
 
-        // same name, all other attributes different -> returns true
-        Person editedAlice = new PersonBuilder(ALICE)
-                .withAge(VALID_AGE_BOB).withGender(VALID_GENDER_BOB).withNric(VALID_NRIC_BOB)
+        // same NRIC, all other attributes different -> returns true
+        Person editedAlice = new PersonBuilder(BOB)
+                .withAge(VALID_AGE_BOB).withGender(VALID_GENDER_BOB).withNric(ALICE.getNric().fullNric)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
                 .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND).build();
         assertTrue(ALICE.isSamePerson(editedAlice));
 
-        // different name, all other attributes same -> returns false
-        editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
+        // different NRIC, all other attributes same -> returns false
+        editedAlice = new PersonBuilder(ALICE).withNric(VALID_NRIC_BOB).build();
         assertFalse(ALICE.isSamePerson(editedAlice));
 
-        // name differs in case, all other attributes same -> returns false
-        Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        // nric differs in case, all other attributes same -> returns true
+        Person editedBob = new PersonBuilder(BOB).withNric(VALID_NRIC_BOB.toLowerCase()).build();
+        assertTrue(BOB.isSamePerson(editedBob));
 
-        // name has trailing spaces, all other attributes same -> returns false
-        String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
-        editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).build();
-        assertFalse(BOB.isSamePerson(editedBob));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -33,17 +33,16 @@ public class PhoneTest {
         assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits
 
         // valid phone numbers
-        assertTrue(Phone.isValidPhone("911")); // exactly 3 numbers
-        assertTrue(Phone.isValidPhone("93121534"));
-        assertTrue(Phone.isValidPhone("124293842033123")); // long phone numbers
+        assertTrue(Phone.isValidPhone("12345678")); // exactly 8 numbers
+        assertTrue(Phone.isValidPhone("76482644")); // random 8 numbers
     }
 
     @Test
     public void equals() {
-        Phone phone = new Phone("999");
+        Phone phone = new Phone("74647364");
 
         // same values -> returns true
-        assertTrue(phone.equals(new Phone("999")));
+        assertTrue(phone.equals(new Phone("74647364")));
 
         // same object -> returns true
         assertTrue(phone.equals(phone));
@@ -55,6 +54,6 @@ public class PhoneTest {
         assertFalse(phone.equals(5.0f));
 
         // different values -> returns false
-        assertFalse(phone.equals(new Phone("995")));
+        assertFalse(phone.equals(new Phone("74644837")));
     }
 }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -22,7 +22,7 @@ public class PersonBuilder {
     public static final String DEFAULT_NAME = "Amy Bee";
     public static final String DEFAULT_AGE = "32";
     public static final String DEFAULT_GENDER = "F";
-    public static final String DEFAULT_NRIC = "S1234567Z";
+    public static final String DEFAULT_NRIC = "S8374626E";
     public static final String DEFAULT_PHONE = "85355255";
     public static final String DEFAULT_EMAIL = "amy@gmail.com";
     public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -32,42 +32,42 @@ public class TypicalPersons {
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withAge("30").withGender("F").withNric("S1234567Z")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
-            .withPhone("94351253")
+            .withPhone("12345678")
             .withTags("friends").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withAge("53").withGender("M").withNric("S1111111Z")
             .withAddress("311, Clementi Ave 2, #02-25")
-            .withEmail("johnd@example.com").withPhone("98765432")
+            .withEmail("johnd@example.com").withPhone("83648172")
             .withTags("owesMoney", "friends").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz")
             .withAge("38").withGender("M").withNric("S2222222Z")
-            .withPhone("95352563")
+            .withPhone("74526283")
             .withEmail("heinz@example.com").withAddress("wall street").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier")
             .withAge("12").withGender("M").withNric("S3333333Z")
-            .withPhone("87652533")
+            .withPhone("84517263")
             .withEmail("cornelia@example.com").withAddress("10th street").withTags("friends").build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer")
             .withAge("43").withGender("F").withNric("F4444444Z")
-            .withPhone("9482224")
+            .withPhone("84635473")
             .withEmail("werner@example.com").withAddress("michegan ave").build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz")
             .withAge("88").withGender("F").withNric("G8888888X")
-            .withPhone("9482427")
+            .withPhone("84657833")
             .withEmail("lydia@example.com").withAddress("little tokyo").build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best")
             .withAge("23").withGender("M").withNric("F7777777D")
-            .withPhone("9482442")
+            .withPhone("39478273")
             .withEmail("anna@example.com").withAddress("4th street").build();
 
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier")
             .withAge("34").withGender("M").withNric("G1234678Z")
-            .withPhone("8482424")
+            .withPhone("84823424")
             .withEmail("stefan@example.com").withAddress("little india").build();
     public static final Person IDA = new PersonBuilder().withName("Ida Mueller")
             .withAge("54").withGender("F").withNric("F9999999Y")
-            .withPhone("8482131")
+            .withPhone("84821331")
             .withEmail("hans@example.com").withAddress("chicago ave").build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}


### PR DESCRIPTION
1. Phone numbers are 8 digits long now
2. NRIC is used for duplicate catching instead of name
3. Testcases updated for the changes mentioned above. updated UpdateCommandTest which may not be correct, specifically execute_allFieldsSpecified_success() so @ArtillerySun need you to check