### PR TITLE
Comment out the parts for manual backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ information such as their treatment, contact information, visit records and futu
 2. <b>Update</b> patient records
 3. <b>Delete</b> patient records
 4. <b>Search</b> patient by ID or name
-5. <b>Backup<b> patient records
+5. <b>Backup</b> patient records
+6. <b>Restore</b> backup file
 
 ---
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -235,46 +235,24 @@ Furthermore, certain edits can cause the AddressBook to behave in unexpected way
 
 The `backup` feature ensures your data is safe by **automatically creating backups** whenever patient records are
 modified. Backups are stored in the `backups` folder located in the root directory of the application.
-In addition to automatic backups, the system also provides a **manual backup option** for users who want more control
-over their data management.
 
-Format: `backup`
+#### **How Automatic Backups Works:**
 
-#### **How Backups works:**
-
-1. **Automatic Backups:**
-    - Each time the patient records are modified (e.g., adding, editing, or deleting a record), the system *
-      *automatically creates a backup**.
-    - These backups are stored in:
-      ```
-      [Application Directory]/backups/
-      ```
-    - Naming Format:
-      ```
-      addressbook-backup-[timestamp].json
-      ```
-    - Example:
-      ```
-      addressbook-backup-2024-10-16_00-00-38-083.json
-      ```
-    - The program retains **only the 10 most recent backups** to manage storage effectively. Older backups are
-      automatically deleted when the limit is exceeded.
-2. **Manual Backups:**
-    - In addition to automatic backups, you can **manually trigger a backup** using the `backup` command anytime.
-    - Command Format:
-      ```
-      backup
-      ```
-    - **Storage Location:**  
-      Manual backups are saved in the same directory:
-      ```
-      [Application Directory]/backups/
-      ```
-    - **Naming Format:**  
-      The manual backup will follow the same naming convention as automatic backups:
-      ```
-      addressbook-backup-[timestamp].json
-      ```
+- Each time the patient records are modified (e.g., adding, editing, or deleting a record), the system **automatically** creates a backup.
+- The program retains **only the 10 most recent backups** to manage storage effectively.
+- Older backups are automatically deleted when the limit is exceeded.
+- These backups are stored in:
+  ```
+  [Application Directory]/backups/
+  ```
+- Naming Format:
+  ```
+  clinicbuddy-backup-[timestamp].json
+  ```
+- Example:
+  ```
+  clinicbuddy-backup-2024-10-16_00-00-38-083.json
+  ```
 
 #### **Accessing Backup Files:**
 
@@ -284,8 +262,6 @@ Format: `backup`
    ```
 2. Identify the backup files using their **timestamp-based naming convention**.
 3. **Move or copy** the files if needed for external storage or manual restoration.
-
-⚠ While the system handles automatic backups, manual backups provide additional flexibility and control when needed.
 
 ### Restoring data from backups : `restore`
 

--- a/src/main/java/seedu/address/logic/commands/BackupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/BackupCommand.java
@@ -1,81 +1,81 @@
-package seedu.address.logic.commands;
-
-import static java.util.Objects.requireNonNull;
-
-import java.io.IOException;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.logging.Logger;
-
-import seedu.address.commons.core.LogsCenter;
-import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.Model;
-
-/**
- * Backs up the current address book to the default backup directory with a timestamped filename.
- */
-public class BackupCommand extends Command {
-    public static final String COMMAND_WORD = "backup";
-
-    public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Creates a backup of the current records in the default backup directory - /backups/.\n"
-            + "Example: " + COMMAND_WORD + " <without arguments>";
-
-    public static final String MESSAGE_SUCCESS = "Backup successful at %s";
-    public static final String MESSAGE_FAILURE = "Backup failed due to: %s";
-    protected static long lastManualBackupTime = 0; // Track last manual backup time
-    private static final Logger logger = LogsCenter.getLogger(BackupCommand.class);
-    private static final long MANUAL_BACKUP_INTERVAL_MS = 5000; // 5 seconds debounce for manual backups
-
-    /**
-     * Constructs a {@code BackupCommand}.
-     */
-    public BackupCommand() {
-    }
-
-    /**
-     * Executes the backup command to save the current state of the address book.
-     *
-     * @param model The model containing the current state of the address book. Must not be null.
-     * @return The result of the command execution.
-     * @throws CommandException if the backup operation fails.
-     */
-    @Override
-    public CommandResult execute(Model model) throws CommandException {
-        requireNonNull(model);
-
-        long currentTime = System.currentTimeMillis();
-
-        // Ensure only one manual backup is allowed within the debounce window
-        if (currentTime - lastManualBackupTime < MANUAL_BACKUP_INTERVAL_MS) {
-            return new CommandResult("Manual backup already triggered. Please wait a few seconds.");
-        }
-
-        lastManualBackupTime = currentTime; // Update the last backup time
-
-        try {
-            // Format the current date and time for the filename
-            String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss-SSS"));
-            String backupPath = String.format("backups/clinicbuddy-backup-%s.json", timestamp);
-
-            logger.info("Starting backup to path: " + backupPath);
-            model.backupData(backupPath); // Use String path here
-
-            logger.info("Backup successful.");
-            return new CommandResult(String.format(MESSAGE_SUCCESS, backupPath));
-        } catch (IOException e) {
-            logger.severe("Backup failed: " + e.getMessage());
-            throw new CommandException(String.format(MESSAGE_FAILURE, e.getMessage()));
-        }
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        return other == this || (other instanceof BackupCommand);
-    }
-
-    @Override
-    public int hashCode() {
-        return COMMAND_WORD.hashCode();
-    }
-}
+//package seedu.address.logic.commands;
+//
+//import static java.util.Objects.requireNonNull;
+//
+//import java.io.IOException;
+//import java.time.LocalDateTime;
+//import java.time.format.DateTimeFormatter;
+//import java.util.logging.Logger;
+//
+//import seedu.address.commons.core.LogsCenter;
+//import seedu.address.logic.commands.exceptions.CommandException;
+//import seedu.address.model.Model;
+//
+///**
+// * Backs up the current address book to the default backup directory with a timestamped filename.
+// */
+//public class BackupCommand extends Command {
+//    public static final String COMMAND_WORD = "backup";
+//
+//    public static final String MESSAGE_USAGE = COMMAND_WORD
+//            + ": Creates a backup of the current records in the default backup directory - /backups/.\n"
+//            + "Example: " + COMMAND_WORD + " <without arguments>";
+//
+//    public static final String MESSAGE_SUCCESS = "Backup successful at %s";
+//    public static final String MESSAGE_FAILURE = "Backup failed due to: %s";
+//    protected static long lastManualBackupTime = 0; // Track last manual backup time
+//    private static final Logger logger = LogsCenter.getLogger(BackupCommand.class);
+//    private static final long MANUAL_BACKUP_INTERVAL_MS = 5000; // 5 seconds debounce for manual backups
+//
+//    /**
+//     * Constructs a {@code BackupCommand}.
+//     */
+//    public BackupCommand() {
+//    }
+//
+//    /**
+//     * Executes the backup command to save the current state of the address book.
+//     *
+//     * @param model The model containing the current state of the address book. Must not be null.
+//     * @return The result of the command execution.
+//     * @throws CommandException if the backup operation fails.
+//     */
+//    @Override
+//    public CommandResult execute(Model model) throws CommandException {
+//        requireNonNull(model);
+//
+//        long currentTime = System.currentTimeMillis();
+//
+//        // Ensure only one manual backup is allowed within the debounce window
+//        if (currentTime - lastManualBackupTime < MANUAL_BACKUP_INTERVAL_MS) {
+//            return new CommandResult("Manual backup already triggered. Please wait a few seconds.");
+//        }
+//
+//        lastManualBackupTime = currentTime; // Update the last backup time
+//
+//        try {
+//            // Format the current date and time for the filename
+//            String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss-SSS"));
+//            String backupPath = String.format("backups/clinicbuddy-backup-%s.json", timestamp);
+//
+//            logger.info("Starting backup to path: " + backupPath);
+//            model.backupData(backupPath); // Use String path here
+//
+//            logger.info("Backup successful.");
+//            return new CommandResult(String.format(MESSAGE_SUCCESS, backupPath));
+//        } catch (IOException e) {
+//            logger.severe("Backup failed: " + e.getMessage());
+//            throw new CommandException(String.format(MESSAGE_FAILURE, e.getMessage()));
+//        }
+//    }
+//
+//    @Override
+//    public boolean equals(Object other) {
+//        return other == this || (other instanceof BackupCommand);
+//    }
+//
+//    @Override
+//    public int hashCode() {
+//        return COMMAND_WORD.hashCode();
+//    }
+//}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -9,7 +9,7 @@ import java.util.regex.Pattern;
 
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.BackupCommand;
+//import seedu.address.logic.commands.BackupCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
@@ -77,8 +77,8 @@ public class AddressBookParser {
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
 
-        case BackupCommand.COMMAND_WORD:
-            return new BackupCommandParser().parse(arguments);
+        //case BackupCommand.COMMAND_WORD:
+            //return new BackupCommandParser().parse(arguments);
 
         case UpdateCommand.COMMAND_WORD:
             return new UpdateCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/BackupCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/BackupCommandParser.java
@@ -1,29 +1,29 @@
-package seedu.address.logic.parser;
-
-import seedu.address.logic.commands.BackupCommand;
-import seedu.address.logic.parser.exceptions.ParseException;
-
-/**
- * Parses input arguments and creates a new BackupCommand object.
- */
-public class BackupCommandParser implements Parser<BackupCommand> {
-
-    /**
-     * Parses the given {@code String} of arguments to create a new {@code BackupCommand} object.
-     *
-     * @param args User-provided arguments for the backup command.
-     * @return A new BackupCommand object.
-     * @throws ParseException if the user input contains unexpected arguments.
-     */
-    @Override
-    public BackupCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
-        if (!trimmedArgs.isEmpty()) {
-            throw new ParseException("Invalid command format!!"
-                    + " The backup command no need to have any arguments.\n"
-                    + BackupCommand.MESSAGE_USAGE);
-        }
-        // Return a new BackupCommand with no arguments (uses the default path internally).
-        return new BackupCommand();
-    }
-}
+//package seedu.address.logic.parser;
+//
+//import seedu.address.logic.commands.BackupCommand;
+//import seedu.address.logic.parser.exceptions.ParseException;
+//
+///**
+// * Parses input arguments and creates a new BackupCommand object.
+// */
+//public class BackupCommandParser implements Parser<BackupCommand> {
+//
+//    /**
+//     * Parses the given {@code String} of arguments to create a new {@code BackupCommand} object.
+//     *
+//     * @param args User-provided arguments for the backup command.
+//     * @return A new BackupCommand object.
+//     * @throws ParseException if the user input contains unexpected arguments.
+//     */
+//    @Override
+//    public BackupCommand parse(String args) throws ParseException {
+//        String trimmedArgs = args.trim();
+//        if (!trimmedArgs.isEmpty()) {
+//            throw new ParseException("Invalid command format!!"
+//                    + " The backup command no need to have any arguments.\n"
+//                    + BackupCommand.MESSAGE_USAGE);
+//        }
+//        // Return a new BackupCommand with no arguments (uses the default path internally).
+//        return new BackupCommand();
+//    }
+//}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,6 +1,5 @@
 package seedu.address.model;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.function.Predicate;
 
@@ -97,13 +96,13 @@ public interface Model {
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
 
-    /**
-     * Backs up the data to the specified file path.
-     *
-     * @param filePath The file path where the backup data will be saved. Must not be null.
-     * @throws IOException if an error occurs during saving the data.
-     */
-    void backupData(String filePath) throws IOException;
+    ///**
+    //* Backs up the data to the specified file path.
+    //*
+    //* @param filePath The file path where the backup data will be saved. Must not be null.
+    //* @throws IOException if an error occurs during saving the data.
+    //*/
+    //void backupData(String filePath) throws IOException;
 
     /**
      * Returns the Storage object associated with the model.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -150,7 +150,7 @@ public class ModelManager implements Model {
         triggerBackup(); // Trigger backup after editing
     }
 
-    @Override
+    /*@Override
     public void backupData(String filePath) throws IOException {
         synchronized (backupManager) {
             logger.info("Starting manual backup.");
@@ -174,7 +174,7 @@ public class ModelManager implements Model {
 
             logger.info("Manual backup completed.");
         }
-    }
+    }*/
 
     // Automatically trigger backup after operations
     protected void triggerBackup() {

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -8,7 +8,6 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BOB;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -186,9 +185,9 @@ public class AddCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
-        @Override
+        /*@Override
         public void backupData(String filePath) throws IOException {
-        }
+        }*/
 
         @Override
         public Storage getStorage() {

--- a/src/test/java/seedu/address/logic/commands/BackupCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/BackupCommandTest.java
@@ -1,199 +1,199 @@
-package seedu.address.logic.commands;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
-import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
-
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Optional;
-import java.util.stream.Stream;
-
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-
-import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
-import seedu.address.model.ReadOnlyAddressBook;
-import seedu.address.model.ReadOnlyUserPrefs;
-import seedu.address.model.UserPrefs;
-import seedu.address.storage.JsonAddressBookStorage;
-import seedu.address.storage.JsonUserPrefsStorage;
-import seedu.address.storage.Storage;
-import seedu.address.storage.StorageManager;
-
-/**
- * Contains integration tests (interaction with the Model) and unit tests for {@code BackupCommand}.
- */
-public class BackupCommandTest {
-
-    @TempDir
-    public Path temporaryFolder;
-    private Model model;
-    private Model expectedModel;
-
-    @BeforeEach
-    public void setUp() throws IOException {
-        JsonAddressBookStorage addressBookStorage =
-                new JsonAddressBookStorage(temporaryFolder.resolve("addressBook.json"));
-        JsonUserPrefsStorage userPrefsStorage =
-                new JsonUserPrefsStorage(temporaryFolder.resolve("userPrefs.json"));
-        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
-
-        model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), storage);
-
-        JsonAddressBookStorage addressBookExpectedStorage =
-                new JsonAddressBookStorage(temporaryFolder.resolve("addressBookExpected.json"));
-        JsonUserPrefsStorage userPrefsExpectedStorage =
-                new JsonUserPrefsStorage(temporaryFolder.resolve("userPrefsExpected.json"));
-        StorageManager expectedStorage = new StorageManager(addressBookExpectedStorage, userPrefsExpectedStorage);
-
-        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), expectedStorage);
-
-        // Reset the static variable before each test
-        BackupCommand.lastManualBackupTime = 0;
-    }
-
-    @AfterEach
-    public void tearDown() throws IOException {
-        // Clean up any backup files created during the test
-        Path backupDir = Path.of("backups");
-        if (Files.exists(backupDir)) {
-            try (Stream<Path> backups = Files.list(backupDir)) {
-                backups.forEach(path -> {
-                    try {
-                        Files.deleteIfExists(path);
-                    } catch (IOException e) {
-                        // Log the error if deletion fails
-                        System.err.println("Failed to delete backup file: " + path);
-                    }
-                });
-            }
-        }
-    }
-
-
-    @Test
-    public void executeBackupCommand_ioException_throwsCommandException() throws IOException {
-        Storage storageStub = createStorageStubForIoException();
-        Model modelWithFailingStorage = new ModelManager(getTypicalAddressBook(), new UserPrefs(), storageStub);
-
-        BackupCommand backupCommand = new BackupCommand();
-
-        assertCommandFailure(backupCommand, modelWithFailingStorage, String.format(
-                BackupCommand.MESSAGE_FAILURE, "Simulated IOException"));
-    }
-
-    private Storage createStorageStubForIoException() {
-        return new Storage() {
-            @Override
-            public void saveAddressBook(ReadOnlyAddressBook addressBook, Path filePath) throws IOException {
-                throw new IOException("Simulated IOException");
-            }
-
-            @Override
-            public void saveAddressBook(ReadOnlyAddressBook addressBook) {
-                // No-op
-            }
-
-            @Override
-            public Optional<UserPrefs> readUserPrefs() {
-                return Optional.empty();
-            }
-
-            @Override
-            public void saveUserPrefs(ReadOnlyUserPrefs userPrefs) {
-                // No-op
-            }
-
-            @Override
-            public Path getAddressBookFilePath() {
-                return null;
-            }
-
-            @Override
-            public Optional<ReadOnlyAddressBook> readAddressBook(Path filePath) {
-                return Optional.empty();
-            }
-
-            @Override
-            public Optional<ReadOnlyAddressBook> readAddressBook() {
-                return Optional.empty();
-            }
-
-            @Override
-            public Path getUserPrefsFilePath() {
-                return null;
-            }
-
-            @Override
-            public Optional<Path> restoreBackup() {
-                return Optional.empty();
-            }
-
-            @Override
-            public void cleanOldBackups(int maxBackups) {
-                // No-op
-            }
-        };
-    }
-
-    @Test
-    public void executeBackupCommand_success() throws Exception {
-        BackupCommand backupCommand = new BackupCommand();
-
-        // Execute the command
-        String timestampPattern = "\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}-\\d{3}";
-        String expectedMessagePattern = String.format(
-                "Backup successful at backups/clinicbuddy-backup-%s.json", timestampPattern
-        );
-
-        // Use regex to match the actual message
-        CommandResult result = backupCommand.execute(model);
-        assertTrue(result.getFeedbackToUser().matches(expectedMessagePattern),
-                "Backup message should match the expected pattern.");
-
-        // Verify that the backup file was created
-        try (Stream<Path> backups = Files.list(Path.of("backups"))) {
-            boolean backupExists = backups.anyMatch(path ->
-                    path.getFileName().toString().matches("clinicbuddy-backup-" + timestampPattern + "\\.json")
-            );
-            assertTrue(backupExists, "Backup file should have been created with the correct format.");
-        }
-    }
-
-    @Test
-    public void executeBackupCommand_storageThrowsIoException_throwsCommandException() throws Exception {
-        // Create a storage stub that simulates an IOException
-        Storage storageStub = createStorageStubForIoException();
-        Model modelWithFailingStorage = new ModelManager(getTypicalAddressBook(), new UserPrefs(), storageStub);
-
-        BackupCommand backupCommand = new BackupCommand();
-
-        assertCommandFailure(backupCommand, modelWithFailingStorage,
-                String.format(BackupCommand.MESSAGE_FAILURE, "Simulated IOException"));
-    }
-
-    @Test
-    public void executeBackupCommand_validBackup_createsBackup() throws Exception {
-        BackupCommand backupCommand = new BackupCommand();
-
-        // Execute the command
-        CommandResult result = backupCommand.execute(model);
-        assertTrue(result.getFeedbackToUser().contains("Backup successful"),
-                "Backup message should contain success indication.");
-
-        // Verify that the backup file was created
-        try (Stream<Path> backups = Files.list(Path.of("backups"))) {
-            boolean backupExists = backups.anyMatch(path ->
-                    path.getFileName().toString().matches(
-                            "clinicbuddy-backup-\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}-\\d{3}\\.json")
-            );
-            assertTrue(backupExists, "Backup file should have been created with the correct format.");
-        }
-    }
-
-}
+//package seedu.address.logic.commands;
+//
+//import static org.junit.jupiter.api.Assertions.assertTrue;
+//import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+//import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+//
+//import java.io.IOException;
+//import java.nio.file.Files;
+//import java.nio.file.Path;
+//import java.util.Optional;
+//import java.util.stream.Stream;
+//
+//import org.junit.jupiter.api.AfterEach;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.io.TempDir;
+//
+//import seedu.address.model.Model;
+//import seedu.address.model.ModelManager;
+//import seedu.address.model.ReadOnlyAddressBook;
+//import seedu.address.model.ReadOnlyUserPrefs;
+//import seedu.address.model.UserPrefs;
+//import seedu.address.storage.JsonAddressBookStorage;
+//import seedu.address.storage.JsonUserPrefsStorage;
+//import seedu.address.storage.Storage;
+//import seedu.address.storage.StorageManager;
+//
+///**
+// * Contains integration tests (interaction with the Model) and unit tests for {@code BackupCommand}.
+// */
+//public class BackupCommandTest {
+//
+//    @TempDir
+//    public Path temporaryFolder;
+//    private Model model;
+//    private Model expectedModel;
+//
+//    @BeforeEach
+//    public void setUp() throws IOException {
+//        JsonAddressBookStorage addressBookStorage =
+//                new JsonAddressBookStorage(temporaryFolder.resolve("addressBook.json"));
+//        JsonUserPrefsStorage userPrefsStorage =
+//                new JsonUserPrefsStorage(temporaryFolder.resolve("userPrefs.json"));
+//        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
+//
+//        model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), storage);
+//
+//        JsonAddressBookStorage addressBookExpectedStorage =
+//                new JsonAddressBookStorage(temporaryFolder.resolve("addressBookExpected.json"));
+//        JsonUserPrefsStorage userPrefsExpectedStorage =
+//                new JsonUserPrefsStorage(temporaryFolder.resolve("userPrefsExpected.json"));
+//        StorageManager expectedStorage = new StorageManager(addressBookExpectedStorage, userPrefsExpectedStorage);
+//
+//        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), expectedStorage);
+//
+//        // Reset the static variable before each test
+//        BackupCommand.lastManualBackupTime = 0;
+//    }
+//
+//    @AfterEach
+//    public void tearDown() throws IOException {
+//        // Clean up any backup files created during the test
+//        Path backupDir = Path.of("backups");
+//        if (Files.exists(backupDir)) {
+//            try (Stream<Path> backups = Files.list(backupDir)) {
+//                backups.forEach(path -> {
+//                    try {
+//                        Files.deleteIfExists(path);
+//                    } catch (IOException e) {
+//                        // Log the error if deletion fails
+//                        System.err.println("Failed to delete backup file: " + path);
+//                    }
+//                });
+//            }
+//        }
+//    }
+//
+//
+//    @Test
+//    public void executeBackupCommand_ioException_throwsCommandException() throws IOException {
+//        Storage storageStub = createStorageStubForIoException();
+//        Model modelWithFailingStorage = new ModelManager(getTypicalAddressBook(), new UserPrefs(), storageStub);
+//
+//        BackupCommand backupCommand = new BackupCommand();
+//
+//        assertCommandFailure(backupCommand, modelWithFailingStorage, String.format(
+//                BackupCommand.MESSAGE_FAILURE, "Simulated IOException"));
+//    }
+//
+//    private Storage createStorageStubForIoException() {
+//        return new Storage() {
+//            @Override
+//            public void saveAddressBook(ReadOnlyAddressBook addressBook, Path filePath) throws IOException {
+//                throw new IOException("Simulated IOException");
+//            }
+//
+//            @Override
+//            public void saveAddressBook(ReadOnlyAddressBook addressBook) {
+//                // No-op
+//            }
+//
+//            @Override
+//            public Optional<UserPrefs> readUserPrefs() {
+//                return Optional.empty();
+//            }
+//
+//            @Override
+//            public void saveUserPrefs(ReadOnlyUserPrefs userPrefs) {
+//                // No-op
+//            }
+//
+//            @Override
+//            public Path getAddressBookFilePath() {
+//                return null;
+//            }
+//
+//            @Override
+//            public Optional<ReadOnlyAddressBook> readAddressBook(Path filePath) {
+//                return Optional.empty();
+//            }
+//
+//            @Override
+//            public Optional<ReadOnlyAddressBook> readAddressBook() {
+//                return Optional.empty();
+//            }
+//
+//            @Override
+//            public Path getUserPrefsFilePath() {
+//                return null;
+//            }
+//
+//            @Override
+//            public Optional<Path> restoreBackup() {
+//                return Optional.empty();
+//            }
+//
+//            @Override
+//            public void cleanOldBackups(int maxBackups) {
+//                // No-op
+//            }
+//        };
+//    }
+//
+//    @Test
+//    public void executeBackupCommand_success() throws Exception {
+//        BackupCommand backupCommand = new BackupCommand();
+//
+//        // Execute the command
+//        String timestampPattern = "\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}-\\d{3}";
+//        String expectedMessagePattern = String.format(
+//                "Backup successful at backups/clinicbuddy-backup-%s.json", timestampPattern
+//        );
+//
+//        // Use regex to match the actual message
+//        CommandResult result = backupCommand.execute(model);
+//        assertTrue(result.getFeedbackToUser().matches(expectedMessagePattern),
+//                "Backup message should match the expected pattern.");
+//
+//        // Verify that the backup file was created
+//        try (Stream<Path> backups = Files.list(Path.of("backups"))) {
+//            boolean backupExists = backups.anyMatch(path ->
+//                    path.getFileName().toString().matches("clinicbuddy-backup-" + timestampPattern + "\\.json")
+//            );
+//            assertTrue(backupExists, "Backup file should have been created with the correct format.");
+//        }
+//    }
+//
+//    @Test
+//    public void executeBackupCommand_storageThrowsIoException_throwsCommandException() throws Exception {
+//        // Create a storage stub that simulates an IOException
+//        Storage storageStub = createStorageStubForIoException();
+//        Model modelWithFailingStorage = new ModelManager(getTypicalAddressBook(), new UserPrefs(), storageStub);
+//
+//        BackupCommand backupCommand = new BackupCommand();
+//
+//        assertCommandFailure(backupCommand, modelWithFailingStorage,
+//                String.format(BackupCommand.MESSAGE_FAILURE, "Simulated IOException"));
+//    }
+//
+//    @Test
+//    public void executeBackupCommand_validBackup_createsBackup() throws Exception {
+//        BackupCommand backupCommand = new BackupCommand();
+//
+//        // Execute the command
+//        CommandResult result = backupCommand.execute(model);
+//        assertTrue(result.getFeedbackToUser().contains("Backup successful"),
+//                "Backup message should contain success indication.");
+//
+//        // Verify that the backup file was created
+//        try (Stream<Path> backups = Files.list(Path.of("backups"))) {
+//            boolean backupExists = backups.anyMatch(path ->
+//                    path.getFileName().toString().matches(
+//                            "clinicbuddy-backup-\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}-\\d{3}\\.json")
+//            );
+//            assertTrue(backupExists, "Backup file should have been created with the correct format.");
+//        }
+//    }
+//
+//}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -14,7 +14,6 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.BackupCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
@@ -95,11 +94,11 @@ public class AddressBookParserTest {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
     }
 
-    @Test
+    /*@Test
     public void parseCommand_backup() throws Exception {
         BackupCommand command = (BackupCommand) parser.parseCommand(BackupCommand.COMMAND_WORD + " ");
         assertEquals(new BackupCommand(), command);
-    }
+    }*/
 
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {

--- a/src/test/java/seedu/address/logic/parser/BackupCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/BackupCommandParserTest.java
@@ -1,45 +1,45 @@
-package seedu.address.logic.parser;
-
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import org.junit.jupiter.api.Test;
-
-import seedu.address.logic.commands.BackupCommand;
-import seedu.address.logic.parser.exceptions.ParseException;
-
-/**
- * Contains unit tests for {@code BackupCommandParser}.
- */
-public class BackupCommandParserTest {
-
-    private final BackupCommandParser parser = new BackupCommandParser();
-
-    @Test
-    public void parse_emptyArgs_returnsBackupCommand() throws Exception {
-        // No arguments provided
-        BackupCommand command = parser.parse("");
-        assertTrue(command instanceof BackupCommand, "Command should be an instance of BackupCommand.");
-    }
-
-    @Test
-    public void parse_whitespaceArgs_returnsBackupCommand() throws Exception {
-        // Only whitespace provided
-        BackupCommand command = parser.parse("   ");
-        assertTrue(command instanceof BackupCommand, "Command should be an instance of BackupCommand.");
-    }
-
-    @Test
-    public void parse_argumentsProvided_throwsParseException() {
-        // Unexpected arguments provided
-        assertThrows(ParseException.class, () -> parser.parse("/some/invalid/path"),
-                "Expected ParseException for providing unexpected arguments.");
-    }
-
-    @Test
-    public void parse_nullArgs_throwsNullPointerException() {
-        // Null argument provided
-        assertThrows(NullPointerException.class, () -> parser.parse(null),
-                "Expected NullPointerException for null input.");
-    }
-}
+//package seedu.address.logic.parser;
+//
+//import static org.junit.jupiter.api.Assertions.assertThrows;
+//import static org.junit.jupiter.api.Assertions.assertTrue;
+//
+//import org.junit.jupiter.api.Test;
+//
+//import seedu.address.logic.commands.BackupCommand;
+//import seedu.address.logic.parser.exceptions.ParseException;
+//
+///**
+// * Contains unit tests for {@code BackupCommandParser}.
+// */
+//public class BackupCommandParserTest {
+//
+//    private final BackupCommandParser parser = new BackupCommandParser();
+//
+//    @Test
+//    public void parse_emptyArgs_returnsBackupCommand() throws Exception {
+//        // No arguments provided
+//        BackupCommand command = parser.parse("");
+//        assertTrue(command instanceof BackupCommand, "Command should be an instance of BackupCommand.");
+//    }
+//
+//    @Test
+//    public void parse_whitespaceArgs_returnsBackupCommand() throws Exception {
+//        // Only whitespace provided
+//        BackupCommand command = parser.parse("   ");
+//        assertTrue(command instanceof BackupCommand, "Command should be an instance of BackupCommand.");
+//    }
+//
+//    @Test
+//    public void parse_argumentsProvided_throwsParseException() {
+//        // Unexpected arguments provided
+//        assertThrows(ParseException.class, () -> parser.parse("/some/invalid/path"),
+//                "Expected ParseException for providing unexpected arguments.");
+//    }
+//
+//    @Test
+//    public void parse_nullArgs_throwsNullPointerException() {
+//        // Null argument provided
+//        assertThrows(NullPointerException.class, () -> parser.parse(null),
+//                "Expected NullPointerException for null input.");
+//    }
+//}

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BOB;
 
@@ -14,7 +13,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.List;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterEach;
@@ -186,7 +184,7 @@ public class ModelManagerTest {
         assertTrue(modelManager.equals(identicalModel), "Comparing with an identical ModelManager should return true.");
     }
 
-    @Test
+    /*@Test
     public void backupData_defaultPath_success() throws Exception {
         // Set up the expected backup directory
         Path backupDir = Path.of("backups");
@@ -211,7 +209,7 @@ public class ModelManagerTest {
                 });
 
         assertTrue(validBackupExists, "Expected a backup file with the correct timestamp format.");
-    }
+    }*/
 
     @Test
     public void modelManager_initialization_validStorage() throws IOException {
@@ -224,7 +222,7 @@ public class ModelManagerTest {
         assertEquals(storage, modelManager.getStorage(), "Storage should be initialized properly.");
     }
 
-    @Test
+    /*@Test
     public void backupData_withValidStorage_noException() throws IOException {
         JsonAddressBookStorage addressBookStorage = new JsonAddressBookStorage(Paths.get("data/addressBook.json"));
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(Paths.get("data/userPrefs.json"));
@@ -238,7 +236,7 @@ public class ModelManagerTest {
         } catch (IOException e) {
             fail("Backup should not throw IOException with valid storage: " + e.getMessage());
         }
-    }
+    }*/
 
     @Test
     public void getStorage_returnsValidStorage() {
@@ -257,10 +255,8 @@ public class ModelManagerTest {
                 "ModelManager should be created successfully even with null storage.");
     }
 
-    /**
-     * Tests the backupData method when storage is null.
-     */
-    @Test
+
+    /*@Test
     public void backupData_nullStorage_throwsIoException() throws IOException {
         // Create a ModelManager without a storage instance
         ModelManager modelManagerWithoutStorage = new ModelManager(new AddressBook(), new UserPrefs(), null);
@@ -286,7 +282,7 @@ public class ModelManagerTest {
             );
             assertTrue(backupExists, "Backup file should be created successfully.");
         }
-    }
+    }*/
 
     @Test
     public void cleanOldBackups_nullStorage_throwsIoException() throws IOException {


### PR DESCRIPTION
Remove the manual backup functionality and the program will backup automatically whenever the patient record is modified. It reduces the complexity of the code and possible bugs while the backup functionality still works automatically.