### PR TITLE
Branch indexed filename

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -59,8 +59,6 @@ public class MainApp extends Application {
         AddressBookStorage addressBookStorage = new JsonAddressBookStorage(userPrefs.getAddressBookFilePath());
         storage = new StorageManager(addressBookStorage, userPrefsStorage);
 
-        Optional<Path> restoredBackup = storage.restoreBackup(); // Restore backup if available.
-
         model = initModelManager(storage, userPrefs);
 
         logic = new LogicManager(model, storage);

--- a/src/main/java/seedu/address/logic/commands/BackupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/BackupCommand.java
@@ -7,24 +7,26 @@ import seedu.address.model.Model;
 
 /**
  * Represents a command to manually create a backup of the current data.
- * Allows an optional file name for the backup, otherwise generates a backup with a default timestamp-based name.
+ * Allows an optional action description for the backup.
  */
 public class BackupCommand extends Command {
     public static final String COMMAND_WORD = "backup";
-    public static final String MESSAGE_SUCCESS = "Manual backup completed successfully.";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Creates a backup with an optional file name.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Creates a backup with an optional action description.\n"
             + "Example: " + COMMAND_WORD + " myBackup";
+    public static final String MESSAGE_SUCCESS = "Backup %d is created successfully.";
 
-    private final String fileName;
+    private final String actionDescription;
 
-    public BackupCommand(String fileName) {
-        this.fileName = fileName;
+    public BackupCommand(String actionDescription) {
+        this.actionDescription = actionDescription;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        model.backupData(fileName); // Pass filename to model
-        return new CommandResult(MESSAGE_SUCCESS);
+        int backupIndex = model.backupData(actionDescription); // Get the index used
+        String message = String.format(MESSAGE_SUCCESS, backupIndex);
+        return new CommandResult(message);
     }
 
     @Override
@@ -35,12 +37,12 @@ public class BackupCommand extends Command {
             return false;
         } else {
             BackupCommand otherCommand = (BackupCommand) other;
-            return Objects.equals(this.fileName, otherCommand.fileName);
+            return Objects.equals(this.actionDescription, otherCommand.actionDescription);
         }
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(fileName);
+        return Objects.hash(actionDescription);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListBackupsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListBackupsCommand.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
+/**
+ * Lists all backup files available in the /backups/ directory.
+ */
+public class ListBackupsCommand extends Command {
+
+    public static final String COMMAND_WORD = "listbackups";
+    public static final String MESSAGE_SUCCESS = "Available backups:\n%s";
+    public static final String MESSAGE_NO_BACKUPS = "No backups available.";
+    public static final String MESSAGE_FAILURE = "Failed to list backups: %s";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        try {
+            String backupsList = model.listAllBackups();
+            if (backupsList.isEmpty()) {
+                return new CommandResult(MESSAGE_NO_BACKUPS);
+            } else {
+                return new CommandResult(String.format(MESSAGE_SUCCESS, backupsList));
+            }
+        } catch (Exception e) {
+            throw new CommandException(String.format(MESSAGE_FAILURE, e.getMessage()), e);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/RestoreCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RestoreCommand.java
@@ -1,75 +1,59 @@
 package seedu.address.logic.commands;
 
-import static java.util.Objects.requireNonNull;
-
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Optional;
+import java.util.Objects;
 
 import seedu.address.commons.exceptions.DataLoadingException;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.ReadOnlyAddressBook;
-import seedu.address.storage.Storage;
 
 /**
- * Restores the data from a backup file.
+ * Restores the data from a backup file by index.
  */
 public class RestoreCommand extends Command {
 
     public static final String COMMAND_WORD = "restore";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " <index>: Restores a backup by index.\n"
+            + "Example: " + COMMAND_WORD + " 3";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Restores the ClinicBuddy from the most recent backup or from a specific file path.\n"
-            + "Example: " + COMMAND_WORD + " [optional file path]";
-
-    public static final String MESSAGE_RESTORE_SUCCESS = "ClinicBuddy restored successfully from %s";
+    public static final String MESSAGE_RESTORE_SUCCESS =
+            "Data restored successfully from backup index %d.";
     public static final String MESSAGE_RESTORE_FAILURE =
-            "Failed to restore ClinicBuddy from backup. Format: restore backups/<backup file name>.";
+            "Failed to restore from backup. Please ensure the index is correct.";
 
-    protected final Optional<Path> filePath;
+    private final int index;
 
     /**
-     * Creates a RestoreCommand to restore from the most recent backup or a specific file path.
+     * Creates a RestoreCommand to restore from a backup by index.
+     *
+     * @param index The index of the backup to restore.
      */
-    public RestoreCommand(Optional<Path> filePath) {
-        this.filePath = filePath;
+    public RestoreCommand(int index) {
+        this.index = index;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        requireNonNull(model);
+        Objects.requireNonNull(model);
 
         try {
-            ReadOnlyAddressBook backupData;
-            Path backupPath;
-
-            // Retrieve the storage from the model
-            Storage storage = model.getStorage();
-
-            if (filePath.isPresent()) {
-                // Restore from a specific file path
-                backupPath = filePath.get();
-                backupData = storage.readAddressBook(backupPath)
-                        .orElseThrow(() -> new DataLoadingException(new Exception("Backup file not found or invalid")));
-            } else {
-                // Restore from the second-most recent backup
-                backupPath = storage.restoreBackup().orElseThrow(() ->
-                        new CommandException("Backup file not found or invalid"));
-                backupData = storage.readAddressBook(backupPath)
-                        .orElseThrow(() -> new DataLoadingException(new Exception("Backup file not found or invalid")));
-            }
-
-            model.setAddressBook(backupData);
-            return new CommandResult(String.format(MESSAGE_RESTORE_SUCCESS, backupPath.toString()));
-
+            Path backupPath = model.restoreBackup(index);
+            return new CommandResult(String.format(MESSAGE_RESTORE_SUCCESS, index));
         } catch (IOException | DataLoadingException e) {
             throw new CommandException(MESSAGE_RESTORE_FAILURE, e);
         }
     }
 
-    public Optional<Path> getFilePath() {
-        return filePath;
+    @Override
+    public boolean equals(Object other) {
+        return other == this
+                || (other instanceof RestoreCommand
+                && index == ((RestoreCommand) other).index);
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(index);
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ListBackupsCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.RestoreCommand;
 import seedu.address.logic.commands.UpdateCommand;
@@ -89,6 +90,9 @@ public class AddressBookParser {
 
         case BackupCommand.COMMAND_WORD:
             return new BackupCommandParser().parse(arguments);
+
+        case ListBackupsCommand.COMMAND_WORD:
+            return new ListBackupsCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/BackupCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/BackupCommandParser.java
@@ -5,16 +5,16 @@ import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
  * Parses input arguments and creates a new BackupCommand object.
- * Supports an optional file name argument for flexibility in naming backups.
+ * Supports an optional action description argument for flexibility in naming backups.
  */
 public class BackupCommandParser implements Parser<BackupCommand> {
 
     @Override
     public BackupCommand parse(String args) throws ParseException {
-        String fileName = args.trim();
-        if (fileName.isEmpty()) {
-            fileName = null; // Use null to signal default naming in BackupCommand
+        String actionDescription = args.trim();
+        if (actionDescription.isEmpty()) {
+            actionDescription = null; // Use null to signal default naming in BackupCommand
         }
-        return new BackupCommand(fileName);
+        return new BackupCommand(actionDescription);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ListBackupsCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListBackupsCommandParser.java
@@ -1,0 +1,18 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.ListBackupsCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ListBackupsCommand object.
+ */
+public class ListBackupsCommandParser implements Parser<ListBackupsCommand> {
+
+    @Override
+    public ListBackupsCommand parse(String args) throws ParseException {
+        if (!args.trim().isEmpty()) {
+            throw new ParseException("The listbackups command does not accept any arguments.");
+        }
+        return new ListBackupsCommand();
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/RestoreCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RestoreCommandParser.java
@@ -1,8 +1,5 @@
 package seedu.address.logic.parser;
 
-import java.nio.file.Path;
-import java.util.Optional;
-
 import seedu.address.logic.commands.RestoreCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -13,12 +10,19 @@ public class RestoreCommandParser implements Parser<RestoreCommand> {
 
     @Override
     public RestoreCommand parse(String args) throws ParseException {
-        if (args.trim().isEmpty()) {
-            return new RestoreCommand(Optional.empty()); // No file path provided, restore the most recent backup
-        } else {
-            // Restore from a specific file path
-            Path backupPath = Path.of(args.trim());
-            return new RestoreCommand(Optional.of(backupPath));
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException("Index is required for restore command.\n" + RestoreCommand.MESSAGE_USAGE);
+        }
+
+        try {
+            int index = Integer.parseInt(trimmedArgs);
+            if (index < 0 || index >= 10) {
+                throw new ParseException("Index must be between 0 and 9.\n" + RestoreCommand.MESSAGE_USAGE);
+            }
+            return new RestoreCommand(index);
+        } catch (NumberFormatException e) {
+            throw new ParseException("Invalid index: " + trimmedArgs + "\n" + RestoreCommand.MESSAGE_USAGE);
         }
     }
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,10 +1,12 @@
 package seedu.address.model;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.commons.exceptions.DataLoadingException;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.person.Person;
 import seedu.address.storage.Storage;
@@ -100,7 +102,12 @@ public interface Model {
     /**
      * Backup current patient record by the file name specified by user.
      */
-    void backupData(String fileName) throws CommandException;
+    int backupData(String actionDescription) throws CommandException;
+
+    /**
+     * Restores the data from a backup by index.
+     */
+    Path restoreBackup(int index) throws IOException, DataLoadingException;
 
     /**
      * Returns the Storage object associated with the model.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -113,4 +113,12 @@ public interface Model {
      * Returns the Storage object associated with the model.
      */
     Storage getStorage();
+
+    /**
+     * Lists all backup files in the backups directory.
+     *
+     * @return A formatted string with the list of backup files.
+     * @throws IOException If an error occurs while accessing the backup directory.
+     */
+    String listAllBackups() throws IOException;
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -54,7 +54,11 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         this.storage = storage;
-        this.backupManager = new BackupManager(Paths.get("backups"));
+        if (storage != null) {
+            this.backupManager = storage.getBackupManager();
+        } else {
+            this.backupManager = new BackupManager(Paths.get("backups"));
+        }
         this.filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
         this.calendar = new Calendar(this.addressBook);
     }
@@ -168,6 +172,14 @@ public class ModelManager implements Model {
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
+    }
+
+    @Override
+    public String listAllBackups() throws IOException {
+        if (storage == null) {
+            throw new IOException("Storage is not initialized!");
+        }
+        return storage.listBackups();
     }
 
     // ============ Backup and Restore Methods ===========================================================

--- a/src/main/java/seedu/address/storage/Storage.java
+++ b/src/main/java/seedu/address/storage/Storage.java
@@ -32,19 +32,26 @@ public interface Storage extends AddressBookStorage, UserPrefsStorage {
     void saveAddressBook(ReadOnlyAddressBook addressBook, Path filePath) throws IOException;
 
     /**
-     * Restores the most recent backup of the address book, if available.
-     *
-     * @return An Optional containing the Path to the most recent backup, if found.
-     * @throws IOException If there is an error accessing the backup.
-     */
-    Optional<Path> restoreBackup() throws IOException;
-
-    /**
      * Cleans up old backups, retaining only the specified number of the most recent backups.
      *
      * @param maxBackups The number of recent backups to retain.
      * @throws IOException If there is an error during cleanup.
      */
     void cleanOldBackups(int maxBackups) throws IOException;
+
+    /**
+     * Lists all available backups in a formatted manner.
+     *
+     * @return A string listing all backup files in the /backups/ directory.
+     * @throws IOException If an error occurs while accessing the backup directory.
+     */
+    String listBackups() throws IOException;
+
+    /**
+     * Returns the BackupManager used by this Storage.
+     *
+     * @return The BackupManager instance.
+     */
+    BackupManager getBackupManager();
 
 }

--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -2,6 +2,7 @@ package seedu.address.storage;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Optional;
 import java.util.logging.Logger;
 
@@ -17,9 +18,9 @@ import seedu.address.model.UserPrefs;
 public class StorageManager implements Storage {
 
     private static final Logger logger = LogsCenter.getLogger(StorageManager.class);
+    protected BackupManager backupManager;
     private final AddressBookStorage addressBookStorage;
     private final UserPrefsStorage userPrefsStorage;
-    private final BackupManager backupManager;
 
     /**
      * Creates a {@code StorageManager} with the given storage and initializes backup management.
@@ -31,7 +32,12 @@ public class StorageManager implements Storage {
     public StorageManager(AddressBookStorage addressBookStorage, UserPrefsStorage userPrefsStorage) throws IOException {
         this.addressBookStorage = addressBookStorage;
         this.userPrefsStorage = userPrefsStorage;
-        this.backupManager = new BackupManager(Path.of("backups")); // Use "backups" directory.
+        // Initialize BackupManager with the backup directory "backups"
+        this.backupManager = new BackupManager(Path.of("backups"));
+    }
+
+    public void setBackupManager(BackupManager backupManager) {
+        this.backupManager = backupManager;
     }
 
     // =================== User Preferences Methods ===================
@@ -65,48 +71,87 @@ public class StorageManager implements Storage {
 
     @Override
     public Optional<ReadOnlyAddressBook> readAddressBook(Path filePath) throws DataLoadingException {
-        logger.fine("Reading AddressBook from: " + filePath);
+        logger.fine("Attempting to read AddressBook from file: " + filePath);
         return addressBookStorage.readAddressBook(filePath);
     }
 
     @Override
     public void saveAddressBook(ReadOnlyAddressBook addressBook) throws IOException {
-        Path filePath = addressBookStorage.getAddressBookFilePath();
-        saveAddressBook(addressBook, filePath);
+        saveAddressBook(addressBook, addressBookStorage.getAddressBookFilePath());
     }
 
     @Override
     public void saveAddressBook(ReadOnlyAddressBook addressBook, Path filePath) throws IOException {
-        logger.fine("Saving AddressBook to: " + filePath);
+        logger.fine("Attempting to write to data file: " + filePath);
         addressBookStorage.saveAddressBook(addressBook, filePath);
     }
 
     // =================== Backup and Restore Methods ===================
 
-    /**
-     * Restores the most recent backup of the AddressBook, if available.
-     *
-     * @return Optional containing the restored backup path, if any.
-     * @throws IOException If restoration fails.
-     */
+    @Override
     public Optional<Path> restoreBackup() throws IOException {
-        Optional<Path> restoredBackup = backupManager.restoreMostRecentBackup();
-        if (restoredBackup.isPresent()) {
-            logger.info("Restored from backup: " + restoredBackup.get());
-        } else {
+        // Attempt to restore the most recent backup
+        List<Path> backups = backupManager.listBackups();
+        if (backups.isEmpty()) {
             logger.warning("No backup available to restore.");
+            return Optional.empty();
         }
-        return restoredBackup;
+
+        // Find the backup with the highest index (most recent based on index rotation)
+        int latestIndex = backups.stream()
+                .mapToInt(backupManager::extractIndex)
+                .max()
+                .orElse(-1);
+
+        if (latestIndex == -1) {
+            logger.warning("No valid backup indices found.");
+            return Optional.empty();
+        }
+
+        try {
+            Path backupPath = backupManager.restoreBackupByIndex(latestIndex);
+            return Optional.of(backupPath);
+        } catch (IOException e) {
+            logger.warning("Failed to restore backup: " + e.getMessage());
+            return Optional.empty();
+        }
     }
 
     /**
-     * Cleans up old backups, keeping only the most recent `maxBackups`.
+     * Restores a backup by its index.
      *
-     * @param maxBackups The number of backups to retain.
-     * @throws IOException If cleanup fails.
+     * @param index The index of the backup to restore.
+     * @return The path to the backup file.
+     * @throws IOException If the backup file is not found or cannot be accessed.
      */
+    public Path restoreBackup(int index) throws IOException {
+        return backupManager.restoreBackupByIndex(index);
+    }
+
+    @Override
     public void cleanOldBackups(int maxBackups) throws IOException {
         backupManager.cleanOldBackups(maxBackups);
     }
 
+    /**
+     * Creates a backup of the address book data.
+     *
+     * @param actionDescription Description for the backup.
+     * @return The index used for the backup.
+     * @throws IOException If an error occurs during backup creation.
+     */
+    public int createBackup(String actionDescription) throws IOException {
+        Path sourcePath = getAddressBookFilePath();
+        return backupManager.createIndexedBackup(sourcePath, actionDescription);
+    }
+
+    /**
+     * Lists all available backups with their indices.
+     *
+     * @return A list of backup file paths.
+     * @throws IOException If an error occurs while accessing the backup directory.
+     */
+    public List<Path> listBackups() throws IOException {
+        return backupManager.listBackups();
+    }
 }

--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -2,7 +2,6 @@ package seedu.address.storage;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Optional;
 import java.util.logging.Logger;
 
@@ -38,6 +37,11 @@ public class StorageManager implements Storage {
 
     public void setBackupManager(BackupManager backupManager) {
         this.backupManager = backupManager;
+    }
+
+    @Override
+    public BackupManager getBackupManager() {
+        return this.backupManager;
     }
 
     // =================== User Preferences Methods ===================
@@ -87,36 +91,6 @@ public class StorageManager implements Storage {
     }
 
     // =================== Backup and Restore Methods ===================
-
-    @Override
-    public Optional<Path> restoreBackup() throws IOException {
-        // Attempt to restore the most recent backup
-        List<Path> backups = backupManager.listBackups();
-        if (backups.isEmpty()) {
-            logger.warning("No backup available to restore.");
-            return Optional.empty();
-        }
-
-        // Find the backup with the highest index (most recent based on index rotation)
-        int latestIndex = backups.stream()
-                .mapToInt(backupManager::extractIndex)
-                .max()
-                .orElse(-1);
-
-        if (latestIndex == -1) {
-            logger.warning("No valid backup indices found.");
-            return Optional.empty();
-        }
-
-        try {
-            Path backupPath = backupManager.restoreBackupByIndex(latestIndex);
-            return Optional.of(backupPath);
-        } catch (IOException e) {
-            logger.warning("Failed to restore backup: " + e.getMessage());
-            return Optional.empty();
-        }
-    }
-
     /**
      * Restores a backup by its index.
      *
@@ -146,12 +120,14 @@ public class StorageManager implements Storage {
     }
 
     /**
-     * Lists all available backups with their indices.
+     * Lists all available backups in a formatted manner.
      *
-     * @return A list of backup file paths.
+     * @return A string listing all backup files in the /backups/ directory.
      * @throws IOException If an error occurs while accessing the backup directory.
      */
-    public List<Path> listBackups() throws IOException {
-        return backupManager.listBackups();
+    @Override
+    public String listBackups() throws IOException {
+        return backupManager.getFormattedBackupList();
     }
+
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -199,6 +199,12 @@ public class AddCommandTest {
         public Storage getStorage() {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public String listAllBackups() throws IOException {
+            // Return an empty string or default message
+            return "";
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/BackupCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/BackupCommandTest.java
@@ -2,14 +2,8 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -19,52 +13,14 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.storage.JsonAddressBookStorage;
-import seedu.address.storage.JsonUserPrefsStorage;
-import seedu.address.storage.StorageManager;
 
+/**
+ * Contains integration tests (interaction with the Model) for {@code BackupCommand}.
+ */
 public class BackupCommandTest {
 
     @TempDir
     public Path temporaryFolder;
-
-    @Test
-    public void execute_backupSuccessful() throws Exception {
-        // Set up the storage and model
-        Path addressBookFilePath = temporaryFolder.resolve("addressBook.json");
-        Path userPrefsFilePath = temporaryFolder.resolve("userPrefs.json");
-        JsonAddressBookStorage addressBookStorage = new JsonAddressBookStorage(addressBookFilePath);
-        JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(userPrefsFilePath);
-        UserPrefs userPrefs = new UserPrefs();
-        userPrefs.setAddressBookFilePath(addressBookFilePath);
-
-        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
-        Model model = new ModelManager(new AddressBook(), userPrefs, storage);
-
-        // Save the address book to ensure the file exists
-        storage.saveAddressBook(model.getAddressBook());
-
-        // Create BackupCommand with file name
-        String fileName = "testBackup";
-        BackupCommand backupCommand = new BackupCommand(fileName);
-
-        // Execute the command
-        CommandResult result = backupCommand.execute(model);
-
-        // Check that the command result is as expected
-        assertEquals(new CommandResult(BackupCommand.MESSAGE_SUCCESS), result);
-
-        // Verify that the backup file exists
-        Path backupDir = Paths.get("backups");
-        assertTrue(Files.exists(backupDir), "Backup directory should exist.");
-
-        try (Stream<Path> paths = Files.walk(backupDir)) {
-            List<Path> backupFiles = paths.filter(Files::isRegularFile).collect(Collectors.toList());
-            boolean backupFileExists = backupFiles.stream()
-                    .anyMatch(path -> path.getFileName().toString().contains(fileName));
-            assertTrue(backupFileExists, "Backup file with specified name should exist.");
-        }
-    }
 
     @Test
     public void execute_backupFails_throwsCommandException() throws Exception {
@@ -72,12 +28,12 @@ public class BackupCommandTest {
         Model model = new ModelManager(new AddressBook(), new UserPrefs(), null);
 
         // Create BackupCommand
-        String fileName = "testBackup";
-        BackupCommand backupCommand = new BackupCommand(fileName);
+        String actionDescription = "testBackup";
+        BackupCommand backupCommand = new BackupCommand(actionDescription);
 
         // Expect CommandException when storage is not initialized
         CommandException exception = assertThrows(CommandException.class, () -> backupCommand.execute(model));
-        assertEquals("Failed to create manual backup: Storage is not initialized!", exception.getMessage());
+        assertEquals("Failed to create backup: Storage is not initialized!", exception.getMessage());
     }
 
     @Test
@@ -90,18 +46,24 @@ public class BackupCommandTest {
         // Same object
         assertEquals(backupCommand1, backupCommand1);
 
-        // Different objects, same fileName
+        // Different objects, same actionDescription
         BackupCommand backupCommand1Copy = new BackupCommand("backup1");
         assertEquals(backupCommand1, backupCommand1Copy);
 
-        // Different fileName
-        assertTrue(!backupCommand1.equals(backupCommand2));
+        // Different actionDescription
+        assertEquals(false, backupCommand1.equals(backupCommand2));
 
-        // Null fileName
+        // Null actionDescription
         assertEquals(backupCommandNull1, backupCommandNull2);
 
         // Different types
-        assertTrue(!backupCommand1.equals(null));
-        assertTrue(!backupCommand1.equals("some string"));
+        assertEquals(false, backupCommand1.equals(null));
+        assertEquals(false, backupCommand1.equals("some string"));
+    }
+
+    private void assertTrue(boolean condition, String message) {
+        if (!condition) {
+            throw new AssertionError(message);
+        }
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ListBackupsCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListBackupsCommandTest.java
@@ -1,0 +1,70 @@
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.ListBackupsCommand;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.storage.JsonAddressBookStorage;
+import seedu.address.storage.JsonUserPrefsStorage;
+import seedu.address.storage.StorageManager;
+import seedu.address.testutil.TypicalPersons;
+
+class ListBackupsCommandTest {
+
+    private Model model;
+    private Path backupDirectory = Path.of("backups");
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        // Clear the backup directory before each test
+        Files.list(backupDirectory)
+                .filter(Files::isRegularFile)
+                .forEach(path -> {
+                    try {
+                        Files.deleteIfExists(path);
+                    } catch (IOException e) {
+                        System.err.println("Failed to delete file " + path);
+                    }
+                });
+
+        // Initialize model with storage containing backup path
+        JsonAddressBookStorage addressBookStorage = new JsonAddressBookStorage(Path.of("data/addressbook.json"));
+        JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(Path.of("data/userprefs.json"));
+        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
+        model = new ModelManager(TypicalPersons.getTypicalAddressBook(), new UserPrefs(), storage);
+    }
+
+    @Test
+    public void execute_noBackups_showsNoBackupsMessage() throws CommandException {
+        ListBackupsCommand command = new ListBackupsCommand();
+        CommandResult result = command.execute(model);
+        assertTrue(result.getFeedbackToUser().contains(ListBackupsCommand.MESSAGE_NO_BACKUPS));
+    }
+
+    @Test
+    public void execute_withBackups_showsBackupList() throws Exception {
+        model.backupData("testBackup"); // Ensure there is at least one backup
+        ListBackupsCommand command = new ListBackupsCommand();
+        CommandResult result = command.execute(model);
+
+        // Verify the result starts with the success message
+        assertTrue(result.getFeedbackToUser().startsWith("Available backups:\n"));
+    }
+
+    @Test
+    public void execute_storageNotInitialized_throwsCommandException() throws IOException {
+        Model modelWithoutStorage = new ModelManager(); // No storage provided
+        ListBackupsCommand command = new ListBackupsCommand();
+        assertThrows(CommandException.class, () -> command.execute(modelWithoutStorage));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/RestoreCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RestoreCommandTest.java
@@ -1,104 +1,83 @@
 package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Optional;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.storage.JsonAddressBookStorage;
 import seedu.address.storage.JsonUserPrefsStorage;
-import seedu.address.storage.Storage;
 import seedu.address.storage.StorageManager;
 
+/**
+ * Contains integration tests (interaction with the Model) for {@code RestoreCommand}.
+ */
 public class RestoreCommandTest {
 
     @TempDir
     public Path temporaryFolder;
 
-    private Model model;
-    private Storage storage;
-
-    @BeforeEach
-    public void setUp() throws IOException {
-        Path addressBookPath = temporaryFolder.resolve("addressBook.json");
-        Path userPrefsPath = temporaryFolder.resolve("userPrefs.json");
-
-        JsonAddressBookStorage addressBookStorage = new JsonAddressBookStorage(addressBookPath);
-        JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(userPrefsPath);
-        storage = new StorageManager(addressBookStorage, userPrefsStorage);
-
-        model = new ModelManager(new AddressBook(), new UserPrefs(), storage);
-    }
-
     @Test
-    public void execute_restoreFromMostRecentBackup_success() throws Exception {
-        // Setup - Create a backup file to restore from
-        Path backupPath = temporaryFolder.resolve("backup.json");
-        AddressBook backupData = new AddressBook();
-        storage.saveAddressBook(backupData, backupPath);
+    public void execute_restoreSuccessful() throws Exception {
+        // Set up the storage and model with temporary directory
+        Path addressBookFilePath = temporaryFolder.resolve("addressBook.json");
+        Path userPrefsFilePath = temporaryFolder.resolve("userPrefs.json");
+        Path backupDirectoryPath = temporaryFolder.resolve("backups");
+        Files.createDirectories(backupDirectoryPath);
 
-        // Perform the restore
-        RestoreCommand restoreCommand = new RestoreCommand(Optional.of(backupPath));
+        JsonAddressBookStorage addressBookStorage = new JsonAddressBookStorage(addressBookFilePath);
+        JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(userPrefsFilePath);
+
+        UserPrefs userPrefs = new UserPrefs();
+        userPrefs.setAddressBookFilePath(addressBookFilePath);
+
+        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
+
+        Model model = new ModelManager(new AddressBook(), userPrefs, storage);
+
+        // Save the address book to ensure the file exists
+        storage.saveAddressBook(model.getAddressBook());
+
+        // Simulate creating a backup at index 0
+        int backupIndex = 0;
+        String actionDescription = "testBackup";
+        model.backupData(actionDescription);
+
+        // Create RestoreCommand with the backup index
+        RestoreCommand restoreCommand = new RestoreCommand(backupIndex);
+
+        // Execute the command
         CommandResult result = restoreCommand.execute(model);
 
-        // Assert the successful restoration
-        assertEquals(
-                String.format(
-                        RestoreCommand.MESSAGE_RESTORE_SUCCESS, backupPath.toString()), result.getFeedbackToUser());
+        // Check that the command result is as expected
+        String expectedMessage = String.format(RestoreCommand.MESSAGE_RESTORE_SUCCESS, backupIndex);
+        assertEquals(expectedMessage, result.getFeedbackToUser());
     }
 
     @Test
-    public void execute_restoreFromSpecificPath_success() throws Exception {
-        // Setup - Create a backup file to restore from
-        Path specificPath = temporaryFolder.resolve("specificBackup.json");
-        AddressBook specificBackupData = new AddressBook();
-        storage.saveAddressBook(specificBackupData, specificPath);
+    public void equals() {
+        RestoreCommand restoreCommand1 = new RestoreCommand(1);
+        RestoreCommand restoreCommand2 = new RestoreCommand(2);
 
-        // Perform the restore from a specific path
-        RestoreCommand restoreCommand = new RestoreCommand(Optional.of(specificPath));
-        CommandResult result = restoreCommand.execute(model);
+        // Same object
+        assertEquals(restoreCommand1, restoreCommand1);
 
-        // Assert the successful restoration
-        assertEquals(
-                String.format(
-                        RestoreCommand.MESSAGE_RESTORE_SUCCESS, specificPath.toString()), result.getFeedbackToUser());
-    }
+        // Different objects, same index
+        RestoreCommand restoreCommand1Copy = new RestoreCommand(1);
+        assertEquals(restoreCommand1, restoreCommand1Copy);
 
-    @Test
-    public void execute_restoreBackupFileNotFound_failure() throws Exception {
-        // Setup - No backup file exists
-        Path nonexistentBackupPath = temporaryFolder.resolve("nonexistentBackup.json");
+        // Different index
+        assertEquals(false, restoreCommand1.equals(restoreCommand2));
 
-        RestoreCommand restoreCommand = new RestoreCommand(Optional.of(nonexistentBackupPath));
-
-        // Assert that trying to restore from a nonexistent backup file throws an exception
-        assertThrows(CommandException.class, () -> restoreCommand.execute(model),
-                RestoreCommand.MESSAGE_RESTORE_FAILURE);
-    }
-
-    @Test
-    public void execute_restoreFromInvalidPath_failure() throws Exception {
-        // Setup - Create an invalid/corrupt backup file
-        Path invalidPath = temporaryFolder.resolve("invalidBackup.json");
-        Files.writeString(invalidPath, "{ invalid json }");
-
-        // Try to restore from the invalid backup file
-        RestoreCommand restoreCommand = new RestoreCommand(Optional.of(invalidPath));
-
-        // Assert that trying to restore from an invalid file throws an exception
-        assertThrows(CommandException.class, () -> restoreCommand.execute(model),
-                RestoreCommand.MESSAGE_RESTORE_FAILURE);
+        // Different types
+        assertEquals(false, restoreCommand1.equals(null));
+        assertEquals(false, restoreCommand1.equals("some string"));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -16,10 +16,12 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.BackupCommand;
 import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ListBackupsCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.UpdateCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -122,6 +124,19 @@ public class AddressBookParserTest {
         String fileName = "myBackup";
         BackupCommand command = (BackupCommand) parser.parseCommand(BackupCommand.COMMAND_WORD + " " + fileName);
         assertEquals(new BackupCommand(fileName), command);
+    }
+
+    @Test
+    public void parseCommandListBackups_noArgs_success() throws Exception {
+        // Check if listbackups command without arguments is parsed correctly
+        Command command = parser.parseCommand(ListBackupsCommand.COMMAND_WORD);
+        assertTrue(command instanceof ListBackupsCommand);
+    }
+
+    @Test
+    public void parseCommandListBackups_withArgs_throwsParseException() {
+        // Ensure listbackups command fails if arguments are provided
+        assertThrows(ParseException.class, () -> parser.parseCommand(ListBackupsCommand.COMMAND_WORD + " extraArg"));
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/BackupCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/BackupCommandParserTest.java
@@ -1,40 +1,37 @@
 package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.BackupCommand;
 
+/**
+ * Contains unit tests for {@code BackupCommandParser}.
+ */
 public class BackupCommandParserTest {
 
-    private BackupCommandParser parser = new BackupCommandParser();
+    private final BackupCommandParser parser = new BackupCommandParser();
 
     @Test
-    public void parse_noArguments_returnsBackupCommandWithNullFileName() throws Exception {
+    public void parse_noArguments_returnsBackupCommandWithNullActionDescription() throws Exception {
         BackupCommand expectedCommand = new BackupCommand(null);
         BackupCommand actualCommand = parser.parse("");
         assertEquals(expectedCommand, actualCommand);
     }
 
     @Test
-    public void parse_withFileName_returnsBackupCommandWithFileName() throws Exception {
-        String fileName = "myBackup";
-        BackupCommand expectedCommand = new BackupCommand(fileName);
-        BackupCommand actualCommand = parser.parse(" " + fileName);
+    public void parse_withActionDescription_returnsBackupCommandWithActionDescription() throws Exception {
+        String actionDescription = "myBackup";
+        BackupCommand expectedCommand = new BackupCommand(actionDescription);
+        BackupCommand actualCommand = parser.parse(" " + actionDescription);
         assertEquals(expectedCommand, actualCommand);
     }
 
     @Test
-    public void parse_withWhitespaceOnly_returnsBackupCommandWithNullFileName() throws Exception {
+    public void parse_withWhitespaceOnly_returnsBackupCommandWithNullActionDescription() throws Exception {
         BackupCommand expectedCommand = new BackupCommand(null);
         BackupCommand actualCommand = parser.parse("   ");
         assertEquals(expectedCommand, actualCommand);
-    }
-
-    @Test
-    public void parse_nullArgs_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> parser.parse(null));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ListBackupsCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ListBackupsCommandParserTest.java
@@ -1,0 +1,25 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.ListBackupsCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+class ListBackupsCommandParserTest {
+
+    private final ListBackupsCommandParser parser = new ListBackupsCommandParser();
+
+    @Test
+    public void parse_emptyArgs_returnsListBackupsCommand() throws Exception {
+        ListBackupsCommand command = parser.parse("");
+        assertTrue(command instanceof ListBackupsCommand);
+    }
+
+    @Test
+    public void parse_withArgs_throwsParseException() {
+        assertThrows(ParseException.class, () -> parser.parse("extraArgs"));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/RestoreCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/RestoreCommandParserTest.java
@@ -1,34 +1,43 @@
 package seedu.address.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.nio.file.Path;
-import java.util.Optional;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.RestoreCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
 
+/**
+ * Contains unit tests for {@code RestoreCommandParser}.
+ */
 public class RestoreCommandParserTest {
 
     private final RestoreCommandParser parser = new RestoreCommandParser();
 
     @Test
-    public void parse_emptyArgs_returnsRestoreCommandWithNoFilePath() throws Exception {
-        RestoreCommand command = parser.parse("");
-        assertTrue(command instanceof RestoreCommand);
-
-        // Verify that the filePath is empty, which means it will restore from the most recent backup
-        assertEquals(Optional.empty(), command.getFilePath());
+    public void parse_validIndex_returnsRestoreCommand() throws Exception {
+        int index = 3;
+        RestoreCommand expectedCommand = new RestoreCommand(index);
+        RestoreCommand actualCommand = parser.parse(" " + index);
+        assertEquals(expectedCommand, actualCommand);
     }
 
     @Test
-    public void parse_specificFilePath_returnsRestoreCommandWithFilePath() throws Exception {
-        String filePath = "backups/specificBackup.json";
-        RestoreCommand command = parser.parse(filePath);
+    public void parse_invalidIndex_throwsParseException() {
+        // Non-integer input
+        assertThrows(ParseException.class, () -> parser.parse("abc"));
 
-        // Verify that the filePath is present and matches the specified path
-        assertEquals(Optional.of(Path.of(filePath)), command.getFilePath());
+        // Negative index
+        assertThrows(ParseException.class, () -> parser.parse("-1"));
+
+        // Index out of range
+        assertThrows(ParseException.class, () -> parser.parse("10"));
+    }
+
+    @Test
+    public void parse_emptyArgs_throwsParseException() {
+        assertThrows(ParseException.class, () -> parser.parse(""));
+        assertThrows(ParseException.class, () -> parser.parse("   "));
     }
 }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -1,29 +1,22 @@
 package seedu.address.model;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.testutil.TypicalPersons.ALICE;
-import static seedu.address.testutil.TypicalPersons.BOB;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.person.Person;
+import seedu.address.storage.BackupManager;
 import seedu.address.storage.JsonAddressBookStorage;
 import seedu.address.storage.JsonUserPrefsStorage;
 import seedu.address.storage.StorageManager;
@@ -34,384 +27,96 @@ import seedu.address.testutil.PersonBuilder;
  */
 public class ModelManagerTest {
 
-    private static final Path BACKUP_DIR = Paths.get("backups");
     @TempDir
     public Path temporaryFolder;
     private ModelManager modelManager;
     private StorageManager storage;
     private UserPrefs userPrefs;
-    private Calendar calendar;
 
     /**
      * Sets up the test environment with the required storage.
      */
     @BeforeEach
     public void setUp() throws IOException {
-        JsonAddressBookStorage addressBookStorage =
-                new JsonAddressBookStorage(temporaryFolder.resolve("addressBook.json"));
-        JsonUserPrefsStorage userPrefsStorage =
-                new JsonUserPrefsStorage(temporaryFolder.resolve("userPrefs.json"));
+        Path addressBookPath = temporaryFolder.resolve("addressBook.json");
+        Path userPrefsPath = temporaryFolder.resolve("userPrefs.json");
+
+        JsonAddressBookStorage addressBookStorage = new JsonAddressBookStorage(addressBookPath);
+        JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(userPrefsPath);
 
         storage = new StorageManager(addressBookStorage, userPrefsStorage); // Initialize storage
         userPrefs = new UserPrefs(); // Initialize userPrefs
-        calendar = new Calendar(new AddressBook()); // initialize calendar
 
-        modelManager = new ModelManager(new AddressBook(), new UserPrefs(), storage);
-    }
+        // Replace the BackupManager with one that uses the temp backup directory
+        Path backupDirectoryPath = temporaryFolder.resolve("backups");
+        Files.createDirectories(backupDirectoryPath);
+        storage.setBackupManager(new BackupManager(backupDirectoryPath));
 
-    @AfterEach
-    public void tearDown() throws IOException {
-        // Clean up any backup files created during the test
-        try (Stream<Path> paths = Files.walk(BACKUP_DIR)) {
-            paths.filter(Files::isRegularFile)
-                    .forEach(path -> {
-                        try {
-                            Files.deleteIfExists(path);
-                        } catch (IOException e) {
-                            System.err.println("Failed to delete file: " + path);
-                            e.printStackTrace();
-                        }
-                    });
-        }
+        modelManager = new ModelManager(new AddressBook(), userPrefs, storage);
     }
 
     /**
      * Tests whether the constructor initializes the model correctly.
      */
     @Test
-    public void constructor() {
+    public void constructor() throws IOException {
         assertEquals(new UserPrefs(), modelManager.getUserPrefs());
         assertEquals(new GuiSettings(), modelManager.getGuiSettings());
         assertEquals(new AddressBook(), new AddressBook(modelManager.getAddressBook()));
-        assertEquals(new Calendar(new AddressBook()), modelManager.getCalendar());
+        assertNotNull(modelManager.getCalendar());
     }
 
     @Test
-    public void setUserPrefs_nullUserPrefs_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> modelManager.setUserPrefs(null));
+    public void backupData_nullActionDescription_backupSuccessful() throws CommandException, IOException {
+        // Save the address book to ensure the file exists
+        storage.saveAddressBook(modelManager.getAddressBook());
+
+        // Perform backup with null action description
+        int backupIndex = modelManager.backupData(null);
+
+        // Verify backup index
+        assertTrue(backupIndex >= 0 && backupIndex < 10, "Backup index should be between 0 and 9.");
     }
 
     @Test
-    public void setUserPrefs_validUserPrefs_copiesUserPrefs() {
-        UserPrefs userPrefs = new UserPrefs();
-        userPrefs.setAddressBookFilePath(Paths.get("address/book/file/path"));
-        userPrefs.setGuiSettings(new GuiSettings(1, 2, 3, 4));
-        modelManager.setUserPrefs(userPrefs);
-        assertEquals(userPrefs, modelManager.getUserPrefs());
-
-        // Modifying userPrefs should not modify modelManager's userPrefs
-        UserPrefs oldUserPrefs = new UserPrefs(userPrefs);
-        userPrefs.setAddressBookFilePath(Paths.get("new/address/book/file/path"));
-        assertEquals(oldUserPrefs, modelManager.getUserPrefs());
-    }
-
-    @Test
-    public void setGuiSettings_nullGuiSettings_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> modelManager.setGuiSettings(null));
-    }
-
-    @Test
-    public void setGuiSettings_validGuiSettings_setsGuiSettings() {
-        GuiSettings guiSettings = new GuiSettings(1, 2, 3, 4);
-        modelManager.setGuiSettings(guiSettings);
-        assertEquals(guiSettings, modelManager.getGuiSettings());
-    }
-
-    @Test
-    public void setAddressBookFilePath_nullPath_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> modelManager.setAddressBookFilePath(null));
-    }
-
-    @Test
-    public void setAddressBookFilePath_validPath_setsAddressBookFilePath() {
-        Path path = Paths.get("address/book/file/path");
-        modelManager.setAddressBookFilePath(path);
-        assertEquals(path, modelManager.getAddressBookFilePath());
-    }
-
-    @Test
-    public void hasPerson_nullPerson_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> modelManager.hasPerson(null));
-    }
-
-    @Test
-    public void hasPerson_personNotInAddressBook_returnsFalse() {
-        assertFalse(modelManager.hasPerson(ALICE));
-    }
-
-    @Test
-    public void hasPerson_personInAddressBook_returnsTrue() {
-        modelManager.addPerson(ALICE);
-        assertTrue(modelManager.hasPerson(ALICE));
-    }
-
-    @Test
-    public void hasAppointment_appointmentInCalendar_returnsTrue() {
-        modelManager.addPerson(ALICE);
-        assertTrue(modelManager.hasAppointment(new PersonBuilder(BOB).withAppointment(ALICE.getAppointment().dateTime)
-                .build()));
-    }
-
-    @Test
-    public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
-        assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredPersonList().remove(0));
-    }
-
-    @Test
-    public void equals_sameObject_returnsTrue() {
-        assertTrue(modelManager.equals(modelManager), "Comparing the same object should return true.");
-    }
-
-    @Test
-    public void equals_nullObject_returnsFalse() {
-        assertFalse(modelManager.equals(null), "Comparing with null should return false.");
-    }
-
-    @Test
-    public void equals_differentClass_returnsFalse() {
-        assertFalse(modelManager.equals("not a ModelManager"),
-                "Comparing with an object of different class should return false.");
-    }
-
-    @Test
-    public void equals_differentAddressBook_returnsFalse() throws IOException {
-        ModelManager differentModel = new ModelManager(new AddressBook(), userPrefs, storage);
-        differentModel.addPerson(ALICE); // Modify to ensure difference
-        assertFalse(modelManager.equals(differentModel),
-                "Comparing with a different address book should return false.");
-    }
-
-    @Test
-    public void equals_identicalModelManager_returnsTrue() throws IOException {
-        ModelManager identicalModel = new ModelManager(new AddressBook(), userPrefs, storage);
-        assertTrue(modelManager.equals(identicalModel), "Comparing with an identical ModelManager should return true.");
-    }
-
-    /*@Test
-    public void backupData_defaultPath_success() throws Exception {
-        // Set up the expected backup directory
-        Path backupDir = Path.of("backups");
-        Files.createDirectories(backupDir); // Ensure the directory exists
-
-        // Run the backup operation
-        assertDoesNotThrow(() -> modelManager.backupData(null)); // Should not throw an exception
-
-        // Wait briefly to allow the backup process to complete
-        Thread.sleep(500); // Ensure the backup file is written before checking
-
-        // Verify that the backup directory contains at least one file
-        List<Path> backupFiles = Files.list(backupDir).toList();
-        assertFalse(backupFiles.isEmpty(), "No backup files found, but one was expected.");
-
-        // Verify the backup file follows the correct format
-        String expectedPrefix = "clinicbuddy-backup-"; // Update the prefix to match what your BackupManager is using
-        boolean validBackupExists = backupFiles.stream()
-                .anyMatch(file -> {
-                    String filename = file.getFileName().toString();
-                    return filename.startsWith(expectedPrefix) && filename.endsWith(".json");
-                });
-
-        assertTrue(validBackupExists, "Expected a backup file with the correct timestamp format.");
-    }*/
-
-    @Test
-    public void modelManager_initialization_validStorage() throws IOException {
-        JsonAddressBookStorage addressBookStorage = new JsonAddressBookStorage(Paths.get("data/addressBook.json"));
-        JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(Paths.get("data/userPrefs.json"));
-        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
-
-        ModelManager modelManager = new ModelManager(new AddressBook(), new UserPrefs(), storage);
-        assertNotNull(modelManager.getStorage(), "Storage should not be null.");
-        assertEquals(storage, modelManager.getStorage(), "Storage should be initialized properly.");
-    }
-
-    /*@Test
-    public void backupData_withValidStorage_noException() throws IOException {
-        JsonAddressBookStorage addressBookStorage = new JsonAddressBookStorage(Paths.get("data/addressBook.json"));
-        JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(Paths.get("data/userPrefs.json"));
-        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
-
-        ModelManager modelManager = new ModelManager(new AddressBook(), new UserPrefs(), storage);
-        String backupPath = "data/backup.json";
-
-        try {
-            modelManager.backupData(backupPath);
-        } catch (IOException e) {
-            fail("Backup should not throw IOException with valid storage: " + e.getMessage());
-        }
-    }*/
-
-    @Test
-    public void getStorage_returnsValidStorage() {
-        assertNotNull(modelManager.getStorage(), "Storage should not be null.");
-        assertEquals(modelManager.getStorage().getClass(),
-                StorageManager.class, "Storage should be an instance of StorageManager.");
-    }
-
-    /**
-     * Tests the constructor that initializes ModelManager with null storage.
-     */
-    @Test
-    public void constructor_nullStorage_success() throws IOException {
-        ModelManager modelManagerWithoutStorage = new ModelManager(new AddressBook(), new UserPrefs(), null);
-        assertNotNull(modelManagerWithoutStorage,
-                "ModelManager should be created successfully even with null storage.");
-    }
-
-
-    /*@Test
-    public void backupData_nullStorage_throwsIoException() throws IOException {
-        // Create a ModelManager without a storage instance
-        ModelManager modelManagerWithoutStorage = new ModelManager(new AddressBook(), new UserPrefs(), null);
-
-        // Verify that calling backupData throws an IOException when the storage is not initialized
-        assertThrows(IOException.class, (
-                ) -> modelManagerWithoutStorage.backupData(null),
-                "Expected IOException when trying to back up with null storage.");
-    }
-
-    @Test
-    public void backupData_withValidStorageAndFilePath_success() throws IOException {
-        // Ensure modelManager is initialized with valid storage
-        modelManager.backupData("backups/clinicbuddy-backup-somepath.json");
-
-        // Ensure backup exists in the backup folder
-        Path backupDir = Path.of("backups");
-
-        try (Stream<Path> backups = Files.list(backupDir)) {
-            boolean backupExists = backups.anyMatch(path ->
-                    path.getFileName().toString().startsWith("clinicbuddy-backup-")
-                            && path.toString().endsWith(".json")
-            );
-            assertTrue(backupExists, "Backup file should be created successfully.");
-        }
-    }*/
-
-    @Test
-    public void cleanOldBackups_nullStorage_throwsIoException() throws IOException {
+    public void backupData_storageNotInitialized_throwsCommandException() throws IOException {
+        // Initialize ModelManager without storage
         ModelManager modelWithoutStorage = new ModelManager(new AddressBook(), new UserPrefs(), null);
 
-        assertThrows(IOException.class, () -> modelWithoutStorage.cleanOldBackups(5),
-                "Expected IOException when storage is not initialized.");
+        // Expect CommandException when storage is not initialized
+        CommandException exception = assertThrows(CommandException.class, () -> modelWithoutStorage.backupData("test"));
+        assertEquals("Failed to create backup: Storage is not initialized!", exception.getMessage());
     }
 
     @Test
-    public void cleanOldBackups_storageNotInitialized_throwsIoException() throws IOException {
-        ModelManager modelWithoutStorage = new ModelManager(new AddressBook(), new UserPrefs(), null);
-        IOException exception = assertThrows(IOException.class, (
-                ) -> modelWithoutStorage.cleanOldBackups(5),
-                "Expected IOException when storage is not initialized.");
-        assertEquals("Storage is not initialized!", exception.getMessage());
-    }
+    public void restoreBackup_validIndex_restorationSuccessful() throws Exception {
+        // Save the address book to ensure the file exists
+        storage.saveAddressBook(modelManager.getAddressBook());
 
-    @Test
-    public void cleanOldBackups_validStorage_executesSuccessfully() throws IOException {
-        JsonAddressBookStorage addressBookStorage =
-                new JsonAddressBookStorage(temporaryFolder.resolve("addressBook.json"));
-        JsonUserPrefsStorage userPrefsStorage =
-                new JsonUserPrefsStorage(temporaryFolder.resolve("userPrefs.json"));
-        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
+        // Perform backup to create a backup at index 0
+        String actionDescription = "testRestore";
+        int backupIndex = modelManager.backupData(actionDescription);
 
-        ModelManager modelManagerWithStorage = new ModelManager(new AddressBook(), new UserPrefs(), storage);
-        assertDoesNotThrow(() -> modelManagerWithStorage.cleanOldBackups(5),
-                "Cleaning old backups with valid storage should not throw any exception.");
-    }
-
-    @Test
-    public void triggerBackup_backupSucceeds_createsBackupFile() throws Exception {
-        // Set up the storage with a valid address book file path
-        Path addressBookFilePath = temporaryFolder.resolve("addressBook.json");
-        JsonAddressBookStorage addressBookStorage = new JsonAddressBookStorage(addressBookFilePath);
-        JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.resolve("userPrefs.json"));
-        UserPrefs userPrefs = new UserPrefs();
-        userPrefs.setAddressBookFilePath(addressBookFilePath);
-        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
-
-        // Initialize ModelManager with storage and userPrefs
-        ModelManager modelManager = new ModelManager(new AddressBook(), userPrefs, storage);
-
-        // Add a person to the address book
+        // Modify the address book to ensure restoration changes it
         Person person = new PersonBuilder().withName("Test Person").build();
         modelManager.addPerson(person);
-
-        // **Save the address book to ensure the file exists**
         storage.saveAddressBook(modelManager.getAddressBook());
 
-        // Delete the person to trigger the backup
-        modelManager.deletePerson(person);
+        // Restore from backup
+        Path restoredPath = modelManager.restoreBackup(backupIndex);
 
-        // Verify that the backup directory exists
-        Path backupDir = Paths.get("backups");
-        assertTrue(Files.exists(backupDir), "Backup directory should exist.");
-
-        // Verify that at least one backup file exists
-        try (Stream<Path> paths = Files.walk(backupDir)) {
-            List<Path> backupFiles = paths.filter(Files::isRegularFile).collect(Collectors.toList());
-            assertFalse(backupFiles.isEmpty(), "Backup files should exist.");
-        }
+        // Verify that the restored data matches the original (before modification)
+        AddressBook restoredAddressBook = new AddressBook(storage.readAddressBook(restoredPath).get());
+        assertEquals(restoredAddressBook, modelManager.getAddressBook(), "Restored data should match backup data.");
     }
 
     @Test
-    public void backupData_validFileName_backupSuccessful() throws Exception {
-        // Set up the storage with a valid address book file path
-        Path addressBookFilePath = temporaryFolder.resolve("addressBook.json");
-        JsonAddressBookStorage addressBookStorage = new JsonAddressBookStorage(addressBookFilePath);
-        JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.resolve("userPrefs.json"));
-        UserPrefs userPrefs = new UserPrefs();
-        userPrefs.setAddressBookFilePath(addressBookFilePath);
-        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
+    public void restoreBackup_storageNotInitialized_throwsIoException() throws IOException {
+        // Initialize ModelManager without storage
+        ModelManager modelWithoutStorage = new ModelManager(new AddressBook(), new UserPrefs(), null);
 
-        // Initialize ModelManager with storage and userPrefs
-        ModelManager modelManager = new ModelManager(new AddressBook(), userPrefs, storage);
-
-        // Save the address book to ensure the file exists
-        storage.saveAddressBook(modelManager.getAddressBook());
-
-        // Call backupData
-        String backupFileName = "testBackup";
-        assertDoesNotThrow(() -> modelManager.backupData(backupFileName));
-
-        // Verify that the backup directory exists
-        Path backupDir = Paths.get("backups");
-        assertTrue(Files.exists(backupDir), "Backup directory should exist.");
-
-        // Verify that at least one backup file exists with the specified name
-        try (Stream<Path> paths = Files.walk(backupDir)) {
-            List<Path> backupFiles = paths.filter(Files::isRegularFile).collect(Collectors.toList());
-            boolean backupFileExists = backupFiles.stream()
-                    .anyMatch(path -> path.getFileName().toString().contains(backupFileName));
-            assertTrue(backupFileExists, "Backup file with specified name should exist.");
-        }
+        // Expect IOException when storage is not initialized
+        IOException exception = assertThrows(IOException.class, () -> modelWithoutStorage.restoreBackup(0));
+        assertEquals("Storage is not initialized!", exception.getMessage());
     }
-
-    @Test
-    public void backupData_nullFileName_backupSuccessful() throws Exception {
-        // Set up the storage with a valid address book file path
-        Path addressBookFilePath = temporaryFolder.resolve("addressBook.json");
-        JsonAddressBookStorage addressBookStorage = new JsonAddressBookStorage(addressBookFilePath);
-        JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.resolve("userPrefs.json"));
-        UserPrefs userPrefs = new UserPrefs();
-        userPrefs.setAddressBookFilePath(addressBookFilePath);
-        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
-
-        // Initialize ModelManager with storage and userPrefs
-        ModelManager modelManager = new ModelManager(new AddressBook(), userPrefs, storage);
-
-        // Save the address book to ensure the file exists
-        storage.saveAddressBook(modelManager.getAddressBook());
-
-        // Call backupData with null file name
-        assertDoesNotThrow(() -> modelManager.backupData(null));
-
-        // Verify that the backup directory exists
-        Path backupDir = Paths.get("backups");
-        assertTrue(Files.exists(backupDir), "Backup directory should exist.");
-
-        // Verify that at least one backup file exists (with generated timestamped name)
-        try (Stream<Path> paths = Files.walk(backupDir)) {
-            List<Path> backupFiles = paths.filter(Files::isRegularFile).collect(Collectors.toList());
-            assertFalse(backupFiles.isEmpty(), "Backup files should exist.");
-        }
-    }
-
 }

--- a/src/test/java/seedu/address/storage/BackupManagerTest.java
+++ b/src/test/java/seedu/address/storage/BackupManagerTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -117,22 +116,6 @@ public class BackupManagerTest {
         // Expect IOException when restoring a non-existent backup
         IOException exception = assertThrows(IOException.class, () -> backupManager.restoreBackupByIndex(invalidIndex));
         assertEquals("Backup with index " + invalidIndex + " not found.", exception.getMessage());
-    }
-
-    @Test
-    public void listBackups_noBackups_returnsEmptyList() throws IOException {
-        List<Path> backups = backupManager.listBackups();
-        assertTrue(backups.isEmpty(), "Backup list should be empty when no backups exist.");
-    }
-
-    @Test
-    public void listBackups_withBackups_returnsBackupList() throws IOException {
-        // Create some backups
-        backupManager.createIndexedBackup(sourceFile, "listTest1");
-        backupManager.createIndexedBackup(sourceFile, "listTest2");
-
-        List<Path> backups = backupManager.listBackups();
-        assertEquals(2, backups.size(), "Backup list should contain 2 backups.");
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/BackupManagerTest.java
+++ b/src/test/java/seedu/address/storage/BackupManagerTest.java
@@ -10,6 +10,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -35,6 +36,22 @@ public class BackupManagerTest {
         Files.writeString(sourceFile, "Sample AddressBook Data");
 
         backupManager = new BackupManager(backupDirectory);
+    }
+
+    /**
+     * Cleans up the backup directory after each test by deleting any files created.
+     */
+    @AfterEach
+    public void tearDown() throws IOException {
+        Files.list(backupDirectory)
+                .filter(Files::isRegularFile)
+                .forEach(path -> {
+                    try {
+                        Files.deleteIfExists(path);
+                    } catch (IOException e) {
+                        System.err.println("Failed to delete file: " + path + " - " + e.getMessage());
+                    }
+                });
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/BackupManagerTest.java
+++ b/src/test/java/seedu/address/storage/BackupManagerTest.java
@@ -1,113 +1,125 @@
 package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.attribute.FileTime;
-import java.util.Optional;
-import java.util.stream.Stream;
+import java.util.List;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test class for BackupManager.
  */
 public class BackupManagerTest {
 
-    private static final Path TEMP_BACKUP_DIR = Paths.get("test-backups");
-    private static final Path TEMP_FILE = TEMP_BACKUP_DIR.resolve("test-addressbook.json");
+    @TempDir
+    public Path temporaryFolder;
     private BackupManager backupManager;
+    private Path backupDirectory;
+    private Path sourceFile;
 
     @BeforeEach
     public void setUp() throws IOException {
-        // Ensure backup directory exists before each test
-        Files.createDirectories(TEMP_BACKUP_DIR);
-        backupManager = new BackupManager(TEMP_BACKUP_DIR);
+        // Set up the backup directory and source file in the temporary folder
+        backupDirectory = temporaryFolder.resolve("backups");
+        Files.createDirectories(backupDirectory);
 
-        // Create a temporary file to simulate address book data
-        Files.writeString(TEMP_FILE, "Sample AddressBook Data");
+        sourceFile = temporaryFolder.resolve("addressBook.json");
+        Files.writeString(sourceFile, "Sample AddressBook Data");
+
+        backupManager = new BackupManager(backupDirectory);
     }
 
-    @AfterEach
-    public void tearDown() throws IOException {
-        // Clean up any backup files created during the test
-        try (Stream<Path> paths = Files.walk(TEMP_BACKUP_DIR)) {
-            paths.filter(Files::isRegularFile)
-                    .forEach(path -> {
-                        try {
-                            Files.deleteIfExists(path);
-                        } catch (IOException e) {
-                            System.err.println("Failed to delete file: " + path);
-                            e.printStackTrace();
-                        }
-                    });
+    @Test
+    public void createIndexedBackup_validParameters_backupCreated() throws IOException {
+        String actionDescription = "testAction";
+        int index = backupManager.createIndexedBackup(sourceFile, actionDescription);
+
+        // Verify that the backup file exists
+        assertTrue(index >= 0 && index < 10, "Backup index should be between 0 and 9.");
+
+        // Check that a backup file with the correct index and description exists
+        boolean backupFileExists = Files.list(backupDirectory)
+                .anyMatch(path -> path
+                        .getFileName()
+                        .toString()
+                        .matches(index + "_" + actionDescription + "_.*\\.json"));
+
+        assertTrue(backupFileExists, "Backup file with specified index and description should exist.");
+    }
+
+    @Test
+    public void createIndexedBackup_nullActionDescription_backupCreated() throws IOException {
+        int index = backupManager.createIndexedBackup(sourceFile, null);
+
+        // Verify that the backup file exists
+        assertTrue(index >= 0 && index < 10, "Backup index should be between 0 and 9.");
+
+        // Check that a backup file with the correct index exists
+        boolean backupFileExists = Files.list(backupDirectory)
+                .anyMatch(path -> path.getFileName().toString().matches(index + "_null_.*\\.json"));
+
+        assertTrue(backupFileExists, "Backup file with specified index should exist.");
+    }
+
+    @Test
+    public void createIndexedBackup_multipleBackups_indicesRotate() throws IOException {
+        // Create multiple backups to test index rotation
+        for (int i = 0; i < 15; i++) { // Exceeds MAX_BACKUPS to test rotation
+            int index = backupManager.createIndexedBackup(sourceFile, "action" + i);
+
+            // Verify that the index cycles between 0 and 9
+            assertEquals(i % 10, index, "Backup index should cycle between 0 and 9.");
         }
     }
 
     @Test
-    public void cleanOldBackups_throwsExceptionForInvalidMaxBackups() throws IOException {
-        try {
-            backupManager.cleanOldBackups(0); // Should trigger IllegalArgumentException
-            fail("Expected IllegalArgumentException to be thrown for maxBackups < 1.");
-        } catch (IllegalArgumentException e) {
-            assertEquals("maxBackups must be at least 1.", e.getMessage(),
-                    "The exception message should match the expected message.");
-        }
+    public void restoreBackupByIndex_validIndex_backupRestored() throws IOException {
+        // Create a backup at index 0
+        int index = backupManager.createIndexedBackup(sourceFile, "restoreTest");
+
+        // Attempt to restore the backup
+        Path restoredPath = backupManager.restoreBackupByIndex(index);
+
+        // Verify that the restored path exists and matches the backup file
+        assertNotNull(restoredPath, "Restored path should not be null.");
+        assertTrue(Files.exists(restoredPath), "Restored backup file should exist.");
     }
 
     @Test
-    public void backupDirectoryInitialization_createsDirectorySuccessfully() throws IOException {
-        Path newBackupDir = TEMP_BACKUP_DIR.resolve("new-backup-dir");
-        new BackupManager(newBackupDir);
-        assertTrue(Files.exists(newBackupDir), "Backup directory should be created successfully.");
+    public void restoreBackupByIndex_invalidIndex_throwsIoException() {
+        int invalidIndex = 9; // Assuming index 9 has no backup
+
+        // Expect IOException when restoring a non-existent backup
+        IOException exception = assertThrows(IOException.class, () -> backupManager.restoreBackupByIndex(invalidIndex));
+        assertEquals("Backup with index " + invalidIndex + " not found.", exception.getMessage());
     }
 
     @Test
-    public void backupDirectoryInitialization_throwsExceptionForNullPath() {
+    public void listBackups_noBackups_returnsEmptyList() throws IOException {
+        List<Path> backups = backupManager.listBackups();
+        assertTrue(backups.isEmpty(), "Backup list should be empty when no backups exist.");
+    }
+
+    @Test
+    public void listBackups_withBackups_returnsBackupList() throws IOException {
+        // Create some backups
+        backupManager.createIndexedBackup(sourceFile, "listTest1");
+        backupManager.createIndexedBackup(sourceFile, "listTest2");
+
+        List<Path> backups = backupManager.listBackups();
+        assertEquals(2, backups.size(), "Backup list should contain 2 backups.");
+    }
+
+    @Test
+    public void backupManager_initializationWithNullPath_throwsIoException() {
         assertThrows(IOException.class, () -> new BackupManager(null));
     }
-
-    @Test
-    public void restoreMostRecentBackup_noBackupAvailable_returnsEmptyOptional() throws IOException {
-        Files.deleteIfExists(TEMP_FILE); // Ensure no backups exist
-        Optional<Path> restoredBackup = backupManager.restoreMostRecentBackup();
-        assertFalse(restoredBackup.isPresent(), "No backup should be available.");
-    }
-
-    @Test
-    public void getFileCreationTime_fileNotFound_returnsCurrentTime() {
-        // Provide a non-existent path to simulate IOException
-        Path nonExistentPath = TEMP_BACKUP_DIR.resolve("non-existent-file.json");
-
-        // Call the method and capture the result
-        FileTime result = backupManager.getFileCreationTime(nonExistentPath);
-
-        // Verify that the fallback time is set to the current time
-        long now = System.currentTimeMillis();
-        assertTrue(Math.abs(result.toMillis() - now) < 1000,
-                "The returned FileTime should be close to the current system time.");
-    }
-
-    @Test
-    public void triggerBackup_createsBackupFileWithCorrectFormat() throws IOException {
-        // Use triggerBackup to create a backup with a specific description.
-        String description = "delete ALICE";
-        backupManager.triggerBackup(TEMP_FILE, description);
-
-        // Verify the backup file is created in the directory with the correct format.
-        boolean backupFileExists = Files.list(TEMP_BACKUP_DIR).anyMatch(path ->
-                path.getFileName().toString().contains(description)
-                        && path.getFileName().toString().endsWith(".json"));
-        assertTrue(backupFileExists, "The backup file should exist and be named with the correct format.");
-    }
-
 }

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -1,7 +1,6 @@
 package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
@@ -9,7 +8,6 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -18,31 +16,40 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.UserPrefs;
 
+/**
+ * Test class for {@code StorageManager}.
+ */
 public class StorageManagerTest {
 
-    private static final Path BACKUP_DIR = Paths.get("backups");
     @TempDir
     public Path testFolder;
 
     private StorageManager storageManager;
+    private Path backupDir;
 
     @BeforeEach
     public void setUp() throws IOException {
         JsonAddressBookStorage addressBookStorage = new JsonAddressBookStorage(getTempFilePath("addressBook.json"));
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(getTempFilePath("userPrefs.json"));
+        backupDir = testFolder.resolve("backups");
+        Files.createDirectories(backupDir);
+
+        // Initialize StorageManager with the backup directory in the temp folder
         storageManager = new StorageManager(addressBookStorage, userPrefsStorage);
+        // Use the public setter to set the BackupManager
+        storageManager.setBackupManager(new BackupManager(backupDir));
     }
 
     @AfterEach
     public void tearDown() throws IOException {
         // Clean up any backup files created during the test
-        try (Stream<Path> paths = Files.walk(BACKUP_DIR)) {
-            paths.filter(Files::isRegularFile)
+        if (Files.exists(backupDir)) {
+            Files.walk(backupDir)
+                    .filter(Files::isRegularFile)
                     .forEach(path -> {
                         try {
                             Files.deleteIfExists(path);
@@ -63,21 +70,11 @@ public class StorageManagerTest {
     @Test
     public void prefsReadSave_success() throws Exception {
         UserPrefs original = new UserPrefs();
-        original.setGuiSettings(new GuiSettings(300, 600, 4, 6));
+        original.setAddressBookFilePath(getTempFilePath("addressBook.json"));
         storageManager.saveUserPrefs(original);
 
         UserPrefs retrieved = storageManager.readUserPrefs().get();
         assertEquals(original, retrieved);
-    }
-
-    @Test
-    public void prefsRead_whenFileMissing_returnsEmptyOptional() throws Exception {
-        JsonUserPrefsStorage missingUserPrefsStorage = new JsonUserPrefsStorage(getTempFilePath("missingPrefs.json"));
-        StorageManager missingStorage = new StorageManager(
-                new JsonAddressBookStorage(getTempFilePath("addressBook.json")), missingUserPrefsStorage);
-
-        Optional<UserPrefs> prefs = missingStorage.readUserPrefs();
-        assertFalse(prefs.isPresent(), "Expected no UserPrefs to be found.");
     }
 
     // ============== AddressBook Storage Tests =================
@@ -91,32 +88,108 @@ public class StorageManagerTest {
         assertEquals(original, new AddressBook(retrieved));
     }
 
-    @Test
-    public void getAddressBookFilePath_returnsCorrectPath() {
-        Path expectedPath = getTempFilePath("addressBook.json");
-        assertEquals(expectedPath, storageManager.getAddressBookFilePath());
-    }
-
     // ============== Backup and Restore Tests =================
 
     @Test
-    public void backupAddressBook_createsBackupFile() throws IOException {
+    public void createBackup_validActionDescription_backupCreated() throws Exception {
+        // Save the address book to ensure the file exists
         AddressBook original = getTypicalAddressBook();
         storageManager.saveAddressBook(original);
 
-        Path backupFile = getTempFilePath("backup.json");
-        storageManager.saveAddressBook(original, backupFile);
+        // Create a backup
+        String actionDescription = "testBackup";
+        int backupIndex = storageManager.createBackup(actionDescription);
 
-        assertTrue(Files.exists(backupFile), "Backup file should be created.");
+        // Verify that the backup file exists
+        assertTrue(backupIndex >= 0 && backupIndex < 10, "Backup index should be between 0 and 9.");
+
+        // Check that a backup file with the correct index and description exists
+        boolean backupFileExists = Files.list(backupDir)
+                .anyMatch(path -> path
+                        .getFileName()
+                        .toString()
+                        .matches(backupIndex + "_" + actionDescription + "_.*\\.json"));
+
+        assertTrue(backupFileExists, "Backup file with specified index and description should exist.");
     }
 
     @Test
+    public void restoreBackup_validIndex_restoresSuccessfully() throws Exception {
+        // Save the address book to ensure the file exists
+        AddressBook original = getTypicalAddressBook();
+        storageManager.saveAddressBook(original);
+
+        // Create a backup
+        String actionDescription = "testRestore";
+        int backupIndex = storageManager.createBackup(actionDescription);
+
+        // Modify the address book
+        AddressBook modifiedAddressBook = new AddressBook();
+        storageManager.saveAddressBook(modifiedAddressBook);
+
+        // Restore the backup
+        Path backupPath = storageManager.restoreBackup(backupIndex);
+
+        // Read the restored data
+        Optional<ReadOnlyAddressBook> restoredData = storageManager.readAddressBook(backupPath);
+        assertTrue(restoredData.isPresent(), "Restored data should be present.");
+
+        // Save the restored data to the main address book file
+        storageManager.saveAddressBook(restoredData.get());
+
+        // Verify that the address book matches the original
+        ReadOnlyAddressBook retrieved = storageManager.readAddressBook().get();
+        assertEquals(original, new AddressBook(retrieved), "Restored address book should match the original.");
+    }
+
+    @Test
+    public void restoreBackup_invalidIndex_throwsIoException() {
+        int invalidIndex = 9; // Assuming index 9 has no backup
+
+        IOException exception = assertThrows(IOException.class, () -> {
+            storageManager.restoreBackup(invalidIndex);
+        });
+
+        assertEquals("Backup with index " + invalidIndex + " not found.", exception.getMessage());
+    }
+
+    @Test
+    public void cleanOldBackups_validMaxBackups_removesOldBackups() throws Exception {
+        // Save the address book to ensure the file exists
+        AddressBook original = getTypicalAddressBook();
+        storageManager.saveAddressBook(original);
+
+        // Create multiple backups
+        for (int i = 0; i < 5; i++) {
+            storageManager.createBackup("testCleanup" + i);
+            // Wait a bit to ensure different timestamps
+            Thread.sleep(10);
+        }
+
+        // Ensure there are 5 backups
+        try (Stream<Path> paths = Files.list(backupDir)) {
+            long backupCount = paths.count();
+            assertEquals(5, backupCount, "There should be 5 backups before cleanup.");
+        }
+
+        // Clean old backups, keeping only 2
+        storageManager.cleanOldBackups(2);
+
+        // Verify that only 2 backups remain
+        try (Stream<Path> paths = Files.list(backupDir)) {
+            long backupCount = paths.count();
+            assertEquals(2, backupCount, "There should be 2 backups after cleanup.");
+        }
+    }
+
+
+    @Test
     public void cleanOldBackups_invalidMaxBackups_throwsIllegalArgumentException() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, (
-                ) -> storageManager.cleanOldBackups(0),
-                "Expected IllegalArgumentException for maxBackups < 1.");
+        // Expect IllegalArgumentException when maxBackups is less than 1
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            storageManager.cleanOldBackups(0);
+        });
 
         assertEquals("maxBackups must be at least 1.", exception.getMessage());
     }
-
 }


### PR DESCRIPTION
- Both automated and manual backup files are saved with a descriptive backup file naming start with an index
- User can restore the backup file by just inputting "restore <index>" instead of the full name of the backup file
- The indices 0-9 are fixed in a sequence from top to bottom
- Every time when the user re run the program, the backup files saved in the last run of the program will still available in the /backups/ path and the new backup file will overwrite the oldest file.
- Allows user to list all of the backup files using "listbackups" command